### PR TITLE
[fix] 404 이슈 수정 #4

### DIFF
--- a/src/main/java/com/triptune/global/config/SecurityConfig.java
+++ b/src/main/java/com/triptune/global/config/SecurityConfig.java
@@ -3,12 +3,15 @@ package com.triptune.global.config;
 import com.triptune.global.exception.CustomAccessDeniedHandler;
 import com.triptune.global.exception.CustomAuthenticationEntryPoint;
 import com.triptune.global.filter.JwtAuthFilter;
+import com.triptune.global.util.HttpRequestEndpointChecker;
 import com.triptune.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,36 +22,42 @@ import static com.triptune.global.config.SecurityConstants.AUTH_WHITELIST;
 
 @RequiredArgsConstructor
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final HttpRequestEndpointChecker endpointChecker;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authz -> authz
-                        .requestMatchers(AUTH_WHITELIST).permitAll()
-//                        .requestMatchers(HttpMethod.GET).permitAll()
-                        .anyRequest().authenticated()
-                )
                 // jwt 이용하기 위해서 세션 관리 상태 없음으로 구성
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling((exceptionHandling) -> exceptionHandling
                         // 인증이 완료되었으나 해당 엔드포인트에 접근할 권한이 없을 경우 발생
                         .accessDeniedHandler(customAccessDeniedHandler)
                         // 인증이 안된 익명의 사용자가 인증이 필요한 엔드포인트로 접근한 경우 발생
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
-                );
-
-        return http.build();
+                )
+                .build();
     }
+
 
     @Bean
     public BCryptPasswordEncoder encoder(){

--- a/src/main/java/com/triptune/global/config/SecurityConstants.java
+++ b/src/main/java/com/triptune/global/config/SecurityConstants.java
@@ -5,7 +5,7 @@ public class SecurityConstants {
     public static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**", "/v3/api-docs/**", "/api/members/join", "/api/members/login", "/api/members/logout",
             "/api/members/refresh", "/api/members/find-id", "/api/members/find-password", "/api/members/change-password",
-            "/api/emails/**", "/api/travels/**", "/error", "/h2-console/**"
+            "/api/emails/**", "/api/travels/**", "/h2-console/**", "/", "/error", "/error/**"
     };
 
     private SecurityConstants(){

--- a/src/main/java/com/triptune/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/triptune/global/exception/CustomAccessDeniedHandler.java
@@ -2,9 +2,11 @@ package com.triptune.global.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.triptune.global.response.ErrorResponse;
+import com.triptune.global.util.HttpRequestEndpointChecker;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -16,22 +18,32 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     // 인증이 완료되었으나 해당 엔드포인트에 접근할 권한이 없을 경우 발생
+
+    private final HttpRequestEndpointChecker endpointChecker;
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpStatus.FORBIDDEN.value());
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        if (!endpointChecker.isEndpointExist(request)){
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "페이지를 찾을 수 없습니다.");
+        } else{
 
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .errorCode(HttpStatus.FORBIDDEN.value())
-                .message("접근 권한이 없습니다.")
-                .build();
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        String result = new ObjectMapper().writeValueAsString(errorResponse);
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                    .errorCode(HttpStatus.FORBIDDEN.value())
+                    .message("접근 권한이 없습니다.")
+                    .build();
 
-        response.getWriter().write(result);
-        response.getWriter().flush();
+            String result = new ObjectMapper().writeValueAsString(errorResponse);
+
+            response.getWriter().write(result);
+            response.getWriter().flush();
+        }
+
     }
 }

--- a/src/main/java/com/triptune/global/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/triptune/global/exception/CustomAuthenticationEntryPoint.java
@@ -2,35 +2,49 @@ package com.triptune.global.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.triptune.global.response.ErrorResponse;
+import com.triptune.global.util.HttpRequestEndpointChecker;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     // 인증이 안된 익명의 사용자가 인증이 필요한 엔드포인트로 접근한 경우 발생
+
+    private final HttpRequestEndpointChecker endpointChecker;
+
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setCharacterEncoding(Charset.defaultCharset().name());
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, NoHandlerFoundException {
+        if (!endpointChecker.isEndpointExist(request)){
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "페이지를 찾을 수 없습니다.");
+        } else{
 
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .errorCode(HttpStatus.UNAUTHORIZED.value())
-                .message("인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.")
-                .build();
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setCharacterEncoding(Charset.defaultCharset().name());
 
-        String result = new ObjectMapper().writeValueAsString(errorResponse);
+            ErrorResponse errorResponse = ErrorResponse.builder()
+                    .errorCode(HttpStatus.UNAUTHORIZED.value())
+                    .message("인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.")
+                    .build();
 
-        response.getWriter().write(result);
-        response.getWriter().flush();
+            String result = new ObjectMapper().writeValueAsString(errorResponse);
+
+            response.getWriter().write(result);
+            response.getWriter().flush();
+        }
+
 
     }
 }

--- a/src/main/java/com/triptune/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/triptune/global/exception/handler/GlobalExceptionHandler.java
@@ -63,7 +63,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public void handle404(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public void handle404(NoHandlerFoundException ex, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        log.info("NoHandlerFoundException: {}", ex.getMessage());
+
         response.sendRedirect(notFoundErrorURL);
     }
 

--- a/src/main/java/com/triptune/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/triptune/global/filter/JwtAuthFilter.java
@@ -41,7 +41,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
         String token = jwtUtil.resolveToken(request);
+
+        if(authorization == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         try{
             if (token != null && jwtUtil.validateToken(token)){

--- a/src/main/java/com/triptune/global/util/HttpRequestEndpointChecker.java
+++ b/src/main/java/com/triptune/global/util/HttpRequestEndpointChecker.java
@@ -1,0 +1,30 @@
+package com.triptune.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerMapping;
+
+@Component
+@RequiredArgsConstructor
+public class HttpRequestEndpointChecker {
+
+    private final DispatcherServlet servlet;
+
+    public boolean isEndpointExist(HttpServletRequest request){
+        for(HandlerMapping handlerMapping: servlet.getHandlerMappings()){
+            try{
+                HandlerExecutionChain executionChain = handlerMapping.getHandler(request);
+
+                if (executionChain != null){
+                    return true;
+                }
+            } catch (Exception e){
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/triptune/domain/member/controller/MemberApiControllerTests.java
+++ b/src/test/java/com/triptune/domain/member/controller/MemberApiControllerTests.java
@@ -48,7 +48,7 @@ public class MemberApiControllerTests {
 
     @Test
     @DisplayName("refreshToken() 실패: refresh token 만료")
-    void failExpiredRefreshToken() throws Exception {
+    void expiredRefreshToken_fail() throws Exception {
         String refreshToken = jwtUtil.createToken("test", -604800000);
 
         mockMvc.perform(post("/api/members/refresh")

--- a/src/test/java/com/triptune/global/config/SecurityConfigTests.java
+++ b/src/test/java/com/triptune/global/config/SecurityConfigTests.java
@@ -1,0 +1,52 @@
+package com.triptune.global.config;
+
+import com.triptune.global.util.HttpRequestEndpointChecker;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SecurityConfigTests {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @MockBean
+    private HttpRequestEndpointChecker endpointChecker;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(){
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    @DisplayName("404 페이지 접속 테스트")
+    void notFoundException_success() throws Exception {
+        mockMvc.perform(get("/testtttttt"))
+                .andExpect(status().isNotFound());
+
+    }
+}


### PR DESCRIPTION
[발생 상황] 
404 에러가 발생해야하는 상황에서 401 에러가 발생

[발생 이유]
400, 500 에러 같은 경우 인증 및 권한 검사 후에 발생하는 에러이기 때문에 상관 없지만 404 에러의 경우 인증 및 권한 검사에 통과하지 못하여 404를 반환하기 전에 401 에러가 먼저 반환됨

* Spring Security의 경우 존재하지 않는 URL이더라도 요청이 들어오면 먼저 이 요청이 인증된 사용자의 의한 것인지를 판단하기 때문에 404 보다 먼저 401을 반환하는 것임

[해결 방법]
1. .requestMatchers("/error").permitAll() 추가 : Spring에서 발생하는 에러는 /error 를 통해서 제공되기 때문에 권한 검사에서 제외시킴 (추가 안할 경우 400, 500, 404 에러 전부 401로 발생됨)
2. 엔드포인트 존재하는지 체크하는 클래스 추가(HttpRequestEndpointChecker)
3. custom 한 exceptionHandling 클래스들(CustomAccessDeniedHandler, CustomAuthenticationEntryPoint)에 엔드포인트 존재 하지 않을 시 404 에러 발생하도록 if문 추가
