### PR TITLE
[feat] 일정 나가기, 공유된 일정 조회, 일정 검색, 권한 체크 구현

### DIFF
--- a/src/main/java/com/triptune/domain/email/controller/EmailController.java
+++ b/src/main/java/com/triptune/domain/email/controller/EmailController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/emails")
 @RequiredArgsConstructor
 @Tag(name = "Email", description = "이메일 관련 API")
-public class EmailApiController {
+public class EmailController {
 
     private final EmailService emailService;
 

--- a/src/main/java/com/triptune/domain/member/controller/MemberController.java
+++ b/src/main/java/com/triptune/domain/member/controller/MemberController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
 @Tag(name = "Member", description = "회원 관련 API")
-public class MemberApiController {
+public class MemberController {
 
     private final MemberService memberService;
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/triptune/domain/member/entity/Member.java
+++ b/src/main/java/com/triptune/domain/member/entity/Member.java
@@ -50,10 +50,9 @@ public class Member {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-
-
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<TravelAttendee> travelAttendeeList = new ArrayList<>();
+
 
     @Builder
     public Member(Long memberId, ProfileImage profileImage, String userId, String password, String refreshToken, boolean isSocialLogin, String nickname, String email, LocalDateTime createdAt, LocalDateTime updatedAt, List<TravelAttendee> travelAttendeeList) {

--- a/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
@@ -1,0 +1,31 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.schedule.service.AttendeeService;
+import com.triptune.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/schedules/{scheduleId}")
+@RequiredArgsConstructor
+@Tag(name = "ScheAttendee", description = "일정 만들기 중 참석자 관련 API")
+public class AttendeeController {
+
+    private final AttendeeService attendeeService;
+
+    @DeleteMapping("/attendees")
+    @Operation(summary = "일정 나가기", description = "일정에 참석자 목록에서 삭제됩니다.")
+    public ApiResponse<?> removeAttendee(@PathVariable(name = "scheduleId") Long scheduleId){
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        attendeeService.removeAttendee(scheduleId, userId);
+        return ApiResponse.okResponse();
+    }
+
+}

--- a/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
@@ -1,6 +1,7 @@
 package com.triptune.domain.schedule.controller;
 
 import com.triptune.domain.schedule.service.AttendeeService;
+import com.triptune.global.aop.AttendeeCheck;
 import com.triptune.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,11 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/schedules/{scheduleId}")
 @RequiredArgsConstructor
-@Tag(name = "ScheAttendee", description = "일정 만들기 중 참석자 관련 API")
+@Tag(name = "Schedule - Attendee", description = "일정 만들기 중 참석자 관련 API")
 public class AttendeeController {
 
     private final AttendeeService attendeeService;
 
+    @AttendeeCheck
     @DeleteMapping("/attendees")
     @Operation(summary = "일정 나가기", description = "일정에 참석자 목록에서 삭제됩니다.")
     public ApiResponse<?> removeAttendee(@PathVariable(name = "scheduleId") Long scheduleId){

--- a/src/main/java/com/triptune/domain/schedule/controller/RouteController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/RouteController.java
@@ -1,0 +1,30 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.schedule.dto.response.RouteResponse;
+import com.triptune.domain.schedule.service.RouteService;
+import com.triptune.global.aop.AttendeeCheck;
+import com.triptune.global.response.pagination.ApiPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/schedules/{scheduleId}")
+@RequiredArgsConstructor
+@Tag(name = "Schedule - Route", description = "일정 만들기 중 여행 루트 관련 API")
+public class RouteController {
+
+    private final RouteService routeService;
+
+    @AttendeeCheck
+    @GetMapping("/routes")
+    @Operation(summary = "여행 루트 조회", description = "저장되어 있는 여행 루트를 조회한다.")
+    public ApiPageResponse<RouteResponse> getTravelRoutes(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam(name = "page") int page){
+        Page<RouteResponse> response = routeService.getTravelRoutes(scheduleId, page);
+
+        return ApiPageResponse.dataResponse(response);
+    }
+
+}

--- a/src/main/java/com/triptune/domain/schedule/controller/ScheduleApiController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/ScheduleApiController.java
@@ -102,4 +102,6 @@ public class ScheduleApiController {
     }
 
 
+
+
 }

--- a/src/main/java/com/triptune/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/ScheduleController.java
@@ -8,7 +8,7 @@ import com.triptune.domain.schedule.dto.response.ScheduleDetailResponse;
 import com.triptune.domain.schedule.dto.response.ScheduleInfoResponse;
 import com.triptune.domain.schedule.service.ScheduleService;
 import com.triptune.domain.travel.dto.response.PlaceResponse;
-import com.triptune.global.response.SuccessResponse;
+import com.triptune.global.aop.AttendeeCheck;
 import com.triptune.global.response.pagination.ApiPageResponse;
 import com.triptune.global.response.ApiResponse;
 import com.triptune.global.response.pagination.ApiSchedulePageResponse;
@@ -25,16 +25,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/schedules")
 @RequiredArgsConstructor
 @Tag(name = "Schedule", description = "일정 만들기 관련 API")
-public class ScheduleApiController {
+public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @GetMapping("")
-    @Operation(summary = "일정 목록 조회", description = "작성한 일정 목록을 조회합니다.")
+    @GetMapping
+    @Operation(summary = "전체 일정 목록 조회", description = "작성한 전체 일정을 조회합니다.")
     public ApiSchedulePageResponse<ScheduleInfoResponse> getSchedules(@RequestParam(name = "page") int page){
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
-
         SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(page, userId);
+
+        return ApiSchedulePageResponse.dataResponse(response);
+    }
+
+    @GetMapping("/shared")
+    @Operation(summary = "공유된 일정 목록 조회", description = "작성한 일정 중 공유된 일정을 조회합니다.")
+    public ApiSchedulePageResponse<ScheduleInfoResponse> getSharedSchedules(@RequestParam(name = "page") int page){
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(page, userId);
 
         return ApiSchedulePageResponse.dataResponse(response);
     }
@@ -49,6 +57,7 @@ public class ScheduleApiController {
     }
 
 
+    @AttendeeCheck
     @GetMapping("/{scheduleId}")
     @Operation(summary = "일정 상세 조회", description = "생성한 일정을 조회합니다.")
     public ApiResponse<ScheduleDetailResponse> getScheduleDetail(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam int page){
@@ -57,6 +66,7 @@ public class ScheduleApiController {
          return ApiResponse.dataResponse(response);
     }
 
+    @AttendeeCheck
     @PatchMapping("/{scheduleId}")
     @Operation(summary = "일정 수정", description = "일정 상세 화면에서 저장 버튼을 누르면 해당 일정이 수정됩니다. 사용자는 저장 작업으로 보지만, 실제로는 일정 수정 작업입니다.")
     public ApiResponse<?> updateSchedule(@PathVariable(name = "scheduleId") Long scheduleId, @Valid @RequestBody UpdateScheduleRequest updateScheduleRequest){
@@ -66,6 +76,7 @@ public class ScheduleApiController {
         return ApiResponse.okResponse();
     }
 
+    @AttendeeCheck
     @DeleteMapping("/{scheduleId}")
     @Operation(summary = "일정 삭제", description = "일정을 삭제합니다.")
     public ApiResponse<?> deleteSchedule(@PathVariable(name = "scheduleId") Long scheduleId){
@@ -74,34 +85,6 @@ public class ScheduleApiController {
         scheduleService.deleteSchedule(scheduleId, userId);
         return ApiResponse.okResponse();
     }
-
-    @GetMapping("/{scheduleId}/travels")
-    @Operation(summary = "여행지 조회", description = "여행지 탭에서 여행지를 제공합니다.")
-    public ApiPageResponse<PlaceResponse> getTravelPlaces(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam int page){
-        Page<PlaceResponse> response = scheduleService.getTravelPlaces(scheduleId, page);
-
-        return ApiPageResponse.dataResponse(response);
-    }
-
-    @GetMapping("/{scheduleId}/travels/search")
-    @Operation(summary = "여행지 검색", description = "여행지 탭에서 여행지를 검색합니다.")
-    public ApiPageResponse<PlaceResponse> searchTravelPlaces(@PathVariable(name = "scheduleId") Long scheduleId,
-                                                             @RequestParam(name = "page") int page,
-                                                             @RequestParam(name = "keyword") String keyword){
-
-        Page<PlaceResponse> response = scheduleService.searchTravelPlaces(scheduleId, page, keyword);
-        return ApiPageResponse.dataResponse(response);
-    }
-
-    @GetMapping("{scheduleId}/routes")
-    @Operation(summary = "여행 루트 조회", description = "저장되어 있는 여행 루트를 조회한다.")
-    public ApiPageResponse<RouteResponse> getTravelRoutes(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam(name = "page") int page){
-        Page<RouteResponse> response = scheduleService.getTravelRoutes(scheduleId, page);
-
-        return ApiPageResponse.dataResponse(response);
-    }
-
-
 
 
 }

--- a/src/main/java/com/triptune/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/ScheduleController.java
@@ -3,13 +3,11 @@ package com.triptune.domain.schedule.controller;
 import com.triptune.domain.schedule.dto.request.CreateScheduleRequest;
 import com.triptune.domain.schedule.dto.request.UpdateScheduleRequest;
 import com.triptune.domain.schedule.dto.response.CreateScheduleResponse;
-import com.triptune.domain.schedule.dto.response.RouteResponse;
 import com.triptune.domain.schedule.dto.response.ScheduleDetailResponse;
 import com.triptune.domain.schedule.dto.response.ScheduleInfoResponse;
+import com.triptune.domain.schedule.enumclass.ScheduleType;
 import com.triptune.domain.schedule.service.ScheduleService;
-import com.triptune.domain.travel.dto.response.PlaceResponse;
 import com.triptune.global.aop.AttendeeCheck;
-import com.triptune.global.response.pagination.ApiPageResponse;
 import com.triptune.global.response.ApiResponse;
 import com.triptune.global.response.pagination.ApiSchedulePageResponse;
 import com.triptune.global.response.pagination.SchedulePageResponse;
@@ -17,7 +15,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,6 +23,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @Tag(name = "Schedule", description = "일정 만들기 관련 API")
 public class ScheduleController {
+
+    private static final String SEARCH_ALL = "all";
 
     private final ScheduleService scheduleService;
 
@@ -46,6 +45,25 @@ public class ScheduleController {
 
         return ApiSchedulePageResponse.dataResponse(response);
     }
+
+    @GetMapping("/search")
+    @Operation(summary = "일정 검색", description = "작성한 전체 일정 중 검색합니다.")
+    public ApiSchedulePageResponse<ScheduleInfoResponse> searchSchedules(
+            @RequestParam(name = "page") int page,
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "type") ScheduleType type){
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        SchedulePageResponse<ScheduleInfoResponse> response;
+
+        if (type == ScheduleType.all){
+            response = scheduleService.searchAllSchedules(page, keyword, userId);
+        } else {
+            response = scheduleService.searchSharedSchedules(page, keyword, userId);
+        }
+
+        return ApiSchedulePageResponse.dataResponse(response);
+    }
+
 
     @PostMapping
     @Operation(summary = "일정 생성", description = "여행 이름, 날짜를 선택해 일정을 생성합니다.")

--- a/src/main/java/com/triptune/domain/schedule/controller/ScheduleTravelController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/ScheduleTravelController.java
@@ -1,0 +1,42 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.schedule.service.ScheduleTravelService;
+import com.triptune.domain.travel.dto.response.PlaceResponse;
+import com.triptune.global.aop.AttendeeCheck;
+import com.triptune.global.response.pagination.ApiPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/schedules/{scheduleId}")
+@RequiredArgsConstructor
+@Tag(name = "Schedule - Travel Place", description = "일정 만들기 중 여행지 관련 API")
+public class ScheduleTravelController {
+
+    private final ScheduleTravelService scheduleTravelService;
+
+    @AttendeeCheck
+    @GetMapping("/travels")
+    @Operation(summary = "여행지 조회", description = "여행지 탭에서 여행지를 제공합니다.")
+    public ApiPageResponse<PlaceResponse> getTravelPlaces(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam int page){
+        Page<PlaceResponse> response = scheduleTravelService.getTravelPlaces(page);
+
+        return ApiPageResponse.dataResponse(response);
+    }
+
+    @AttendeeCheck
+    @GetMapping("/travels/search")
+    @Operation(summary = "여행지 검색", description = "여행지 탭에서 여행지를 검색합니다.")
+    public ApiPageResponse<PlaceResponse> searchTravelPlaces(@PathVariable(name = "scheduleId") Long scheduleId,
+                                                             @RequestParam(name = "page") int page,
+                                                             @RequestParam(name = "keyword") String keyword){
+
+        Page<PlaceResponse> response = scheduleTravelService.searchTravelPlaces(page, keyword);
+        return ApiPageResponse.dataResponse(response);
+    }
+
+}

--- a/src/main/java/com/triptune/domain/schedule/dto/AttendeeDTO.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/AttendeeDTO.java
@@ -21,7 +21,7 @@ public class AttendeeDTO {
         this.permission = permission;
     }
 
-    public static AttendeeDTO entityToDTO(TravelAttendee attendee){
+    public static AttendeeDTO from(TravelAttendee attendee){
         return AttendeeDTO.builder()
                 .attendeeId(attendee.getAttendeeId())
                 .userId(attendee.getMember().getUserId())

--- a/src/main/java/com/triptune/domain/schedule/dto/response/CreateScheduleResponse.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/response/CreateScheduleResponse.java
@@ -16,7 +16,7 @@ public class CreateScheduleResponse {
         this.scheduleId = scheduleId;
     }
 
-    public static CreateScheduleResponse entityToDto(TravelSchedule travelSchedule){
+    public static CreateScheduleResponse from(TravelSchedule travelSchedule){
         return CreateScheduleResponse.builder()
                 .scheduleId(travelSchedule.getScheduleId())
                 .build();

--- a/src/main/java/com/triptune/domain/schedule/dto/response/RouteResponse.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/response/RouteResponse.java
@@ -37,7 +37,7 @@ public class RouteResponse {
     }
 
 
-    public static RouteResponse entityToDto(TravelRoute travelRoute){
+    public static RouteResponse from(TravelRoute travelRoute){
         TravelPlace travelPlace = travelRoute.getTravelPlace();
 
         return RouteResponse.builder()

--- a/src/main/java/com/triptune/domain/schedule/dto/response/RouteResponse.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/response/RouteResponse.java
@@ -37,7 +37,9 @@ public class RouteResponse {
     }
 
 
-    public static RouteResponse entityToDto(TravelRoute travelRoute, TravelPlace travelPlace){
+    public static RouteResponse entityToDto(TravelRoute travelRoute){
+        TravelPlace travelPlace = travelRoute.getTravelPlace();
+
         return RouteResponse.builder()
                 .routeOrder(travelRoute.getRouteOrder())
                 .placeId(travelPlace.getPlaceId())

--- a/src/main/java/com/triptune/domain/schedule/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/response/ScheduleDetailResponse.java
@@ -34,7 +34,7 @@ public class ScheduleDetailResponse {
         this.placeList = placeList;
     }
 
-    public static ScheduleDetailResponse entityToDTO(TravelSchedule schedule, PageResponse<PlaceResponse> simplePlaces, List<AttendeeDTO> attendeeList){
+    public static ScheduleDetailResponse from(TravelSchedule schedule, PageResponse<PlaceResponse> placeResponse, List<AttendeeDTO> attendeeList){
         return ScheduleDetailResponse.builder()
                 .scheduleName(schedule.getScheduleName())
                 .startDate(schedule.getStartDate())
@@ -42,7 +42,7 @@ public class ScheduleDetailResponse {
                 .createdAt(schedule.getCreatedAt())
                 .updateAt(schedule.getUpdatedAt())
                 .attendeeList(attendeeList)
-                .placeList(simplePlaces)
+                .placeList(placeResponse)
                 .build();
     }
 }

--- a/src/main/java/com/triptune/domain/schedule/dto/response/ScheduleInfoResponse.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/response/ScheduleInfoResponse.java
@@ -46,7 +46,7 @@ public class ScheduleInfoResponse {
         return sinceUp;
     }
 
-    public static ScheduleInfoResponse entityToDto(TravelSchedule schedule, AttendeeRole role, String thumbnailUrl, AuthorDTO author){
+    public static ScheduleInfoResponse from(TravelSchedule schedule, AttendeeRole role, String thumbnailUrl, AuthorDTO author){
         return ScheduleInfoResponse.builder()
                 .scheduleId(schedule.getScheduleId())
                 .role(role)

--- a/src/main/java/com/triptune/domain/schedule/entity/TravelAttendee.java
+++ b/src/main/java/com/triptune/domain/schedule/entity/TravelAttendee.java
@@ -44,4 +44,17 @@ public class TravelAttendee {
         this.role = role;
         this.permission = permission;
     }
+
+    public static TravelAttendee of(TravelSchedule schedule, Member member){
+        return TravelAttendee.builder()
+                .travelSchedule(schedule)
+                .member(member)
+                .role(AttendeeRole.AUTHOR)
+                .permission(AttendeePermission.ALL)
+                .build();
+    }
+
+    public boolean isAuthor(){
+        return AttendeeRole.AUTHOR.equals(this.role);
+    }
 }

--- a/src/main/java/com/triptune/domain/schedule/entity/TravelSchedule.java
+++ b/src/main/java/com/triptune/domain/schedule/entity/TravelSchedule.java
@@ -57,7 +57,7 @@ public class TravelSchedule {
         this.travelRouteList = travelRouteList;
     }
 
-    public static TravelSchedule of(CreateScheduleRequest request){
+    public static TravelSchedule from(CreateScheduleRequest request){
         return TravelSchedule.builder()
                 .scheduleName(request.getScheduleName())
                 .startDate(request.getStartDate())

--- a/src/main/java/com/triptune/domain/schedule/enumclass/ScheduleType.java
+++ b/src/main/java/com/triptune/domain/schedule/enumclass/ScheduleType.java
@@ -1,0 +1,5 @@
+package com.triptune.domain.schedule.enumclass;
+
+public enum ScheduleType {
+    all, share;
+}

--- a/src/main/java/com/triptune/domain/schedule/repository/TravelAttendeeRepository.java
+++ b/src/main/java/com/triptune/domain/schedule/repository/TravelAttendeeRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TravelAttendeeRepository extends JpaRepository<TravelAttendee, Long> {
     List<TravelAttendee> findAllByTravelSchedule_ScheduleId(Long scheduleId);
+    boolean existsByTravelSchedule_ScheduleIdAndMember_UserId(Long scheduleId, String userId);
+    Optional<TravelAttendee> findByTravelSchedule_ScheduleIdAndMember_UserId(Long scheduleId, String userId);
 }

--- a/src/main/java/com/triptune/domain/schedule/repository/TravelScheduleCustomRepository.java
+++ b/src/main/java/com/triptune/domain/schedule/repository/TravelScheduleCustomRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface TravelScheduleCustomRepository {
-    Page<TravelSchedule> findTravelSchedulesByAttendee(Pageable pageable, Long memberId);
-    Integer getTotalElementByTravelSchedules(Long memberId);
+    Page<TravelSchedule> findTravelSchedulesByUserId(Pageable pageable, String userId);
+    Page<TravelSchedule> findSharedTravelSchedulesByUserId(Pageable pageable, String userId);
+    Integer countTravelSchedulesByUserId(String userId);
+    Integer countSharedTravelSchedulesByUserId(String userId);
 }

--- a/src/main/java/com/triptune/domain/schedule/repository/TravelScheduleCustomRepository.java
+++ b/src/main/java/com/triptune/domain/schedule/repository/TravelScheduleCustomRepository.java
@@ -9,4 +9,8 @@ public interface TravelScheduleCustomRepository {
     Page<TravelSchedule> findSharedTravelSchedulesByUserId(Pageable pageable, String userId);
     Integer countTravelSchedulesByUserId(String userId);
     Integer countSharedTravelSchedulesByUserId(String userId);
+    Page<TravelSchedule> searchTravelSchedulesByUserIdAndKeyword(Pageable pageable, String keyword, String userId);
+    Integer countTravelSchedulesByUserIdAndKeyword(String keyword, String userId);
+    Page<TravelSchedule> searchSharedTravelSchedulesByUserIdAndKeyword(Pageable pageable, String keyword, String userId);
+    Integer countSharedTravelSchedulesByUserIdAndKeyword(String keyword, String userId);
 }

--- a/src/main/java/com/triptune/domain/schedule/service/AttendeeService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/AttendeeService.java
@@ -1,0 +1,48 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import com.triptune.global.exception.DataNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AttendeeService {
+
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+
+    public void removeAttendee(Long scheduleId, String userId) {
+        TravelSchedule schedule = travelScheduleRepository.findByScheduleId(scheduleId)
+                .orElseThrow(() -> new DataNotFoundException(ErrorCode.SCHEDULE_NOT_FOUND));
+
+        TravelAttendee attendee = getAttendeeInfo(userId, schedule);
+
+        if (isAuthor(attendee)){
+            throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE);
+        }
+
+        travelAttendeeRepository.deleteById(attendee.getAttendeeId());
+    }
+
+
+    public TravelAttendee getAttendeeInfo(String userId, TravelSchedule schedule){
+        return schedule.getTravelAttendeeList().stream()
+                .filter(attendee -> attendee.getMember().getUserId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> new ForbiddenScheduleException(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE));
+
+    }
+
+    public boolean isAuthor(TravelAttendee attendee){
+        return attendee.getRole().equals(AttendeeRole.AUTHOR);
+    }
+}

--- a/src/main/java/com/triptune/domain/schedule/service/AttendeeService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/AttendeeService.java
@@ -1,7 +1,6 @@
 package com.triptune.domain.schedule.service;
 
 import com.triptune.domain.schedule.entity.TravelAttendee;
-import com.triptune.domain.schedule.entity.TravelSchedule;
 import com.triptune.domain.schedule.enumclass.AttendeeRole;
 import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
 import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
@@ -17,16 +16,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AttendeeService {
 
-    private final TravelScheduleRepository travelScheduleRepository;
     private final TravelAttendeeRepository travelAttendeeRepository;
 
     public void removeAttendee(Long scheduleId, String userId) {
-        TravelSchedule schedule = travelScheduleRepository.findByScheduleId(scheduleId)
-                .orElseThrow(() -> new DataNotFoundException(ErrorCode.SCHEDULE_NOT_FOUND));
+        TravelAttendee attendee = travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(scheduleId, userId)
+                .orElseThrow(() -> new ForbiddenScheduleException(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE));
 
-        TravelAttendee attendee = getAttendeeInfo(userId, schedule);
-
-        if (isAuthor(attendee)){
+        if (attendee.isAuthor()){
             throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE);
         }
 
@@ -34,15 +30,4 @@ public class AttendeeService {
     }
 
 
-    public TravelAttendee getAttendeeInfo(String userId, TravelSchedule schedule){
-        return schedule.getTravelAttendeeList().stream()
-                .filter(attendee -> attendee.getMember().getUserId().equals(userId))
-                .findFirst()
-                .orElseThrow(() -> new ForbiddenScheduleException(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE));
-
-    }
-
-    public boolean isAuthor(TravelAttendee attendee){
-        return attendee.getRole().equals(AttendeeRole.AUTHOR);
-    }
 }

--- a/src/main/java/com/triptune/domain/schedule/service/RouteService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/RouteService.java
@@ -1,0 +1,36 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.schedule.dto.response.RouteResponse;
+import com.triptune.domain.schedule.entity.TravelRoute;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import com.triptune.global.exception.DataNotFoundException;
+import com.triptune.global.util.PageUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final TravelRouteRepository travelRouteRepository;
+    private final TravelScheduleRepository travelScheduleRepository;
+
+    /**
+     * 여행 루트 조회
+     * @param scheduleId: 일정 인덱스
+     * @param page: 페이지 수
+     * @return Page<RouteResponse>: 여행 루트 정보로 구성된 페이지 dto
+     */
+    public Page<RouteResponse> getTravelRoutes(Long scheduleId, int page) {
+        Pageable pageable = PageUtil.defaultPageable(page);
+        Page<TravelRoute> travelRoutes = travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, scheduleId);
+
+        return travelRoutes.map(RouteResponse::entityToDto);
+    }
+}

--- a/src/main/java/com/triptune/domain/schedule/service/RouteService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/RouteService.java
@@ -4,8 +4,6 @@ import com.triptune.domain.schedule.dto.response.RouteResponse;
 import com.triptune.domain.schedule.entity.TravelRoute;
 import com.triptune.domain.schedule.repository.TravelRouteRepository;
 import com.triptune.domain.schedule.repository.TravelScheduleRepository;
-import com.triptune.global.enumclass.ErrorCode;
-import com.triptune.global.exception.DataNotFoundException;
 import com.triptune.global.util.PageUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +29,6 @@ public class RouteService {
         Pageable pageable = PageUtil.defaultPageable(page);
         Page<TravelRoute> travelRoutes = travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, scheduleId);
 
-        return travelRoutes.map(RouteResponse::entityToDto);
+        return travelRoutes.map(RouteResponse::from);
     }
 }

--- a/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
@@ -203,13 +203,13 @@ public class ScheduleService {
         // 여행지 정보: Page<TravelPlace> -> PageResponse<TravelSimpleResponse> 로 변경
         Pageable pageable = PageUtil.defaultPageable(page);
         Page<PlaceResponse> travelPlacesDTO = travelPlaceRepository.findAllByAreaData(pageable, "대한민국", "서울", "중구")
-                .map(PlaceResponse::entityToDto);
+                .map(PlaceResponse::from);
 
         PageResponse<PlaceResponse> placeResponses = PageResponse.of(travelPlacesDTO);
 
         List<AttendeeDTO> attendeeDTOList = travelAttendeeRepository.findAllByTravelSchedule_ScheduleId(schedule.getScheduleId())
                 .stream()
-                .map(AttendeeDTO::entityToDTO)
+                .map(AttendeeDTO::from)
                 .toList();
 
         return ScheduleDetailResponse.from(schedule, placeResponses, attendeeDTOList);

--- a/src/main/java/com/triptune/domain/schedule/service/ScheduleTravelService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/ScheduleTravelService.java
@@ -1,6 +1,5 @@
 package com.triptune.domain.schedule.service;
 
-import com.triptune.domain.schedule.repository.TravelScheduleRepository;
 import com.triptune.domain.travel.dto.response.PlaceResponse;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelPlaceRepository;
@@ -27,7 +26,7 @@ public class ScheduleTravelService {
         Pageable pageable = PageUtil.defaultPageable(page);
 
         return travelPlaceRepository.findAllByAreaData(pageable, "대한민국", "서울", "중구")
-                .map(PlaceResponse::entityToDto);
+                .map(PlaceResponse::from);
 
     }
 
@@ -42,7 +41,7 @@ public class ScheduleTravelService {
         Pageable pageable = PageUtil.defaultPageable(page);
         Page<TravelPlace> travelPlaces = travelPlaceRepository.searchTravelPlaces(pageable, keyword);
 
-        return travelPlaces.map(PlaceResponse::entityToDto);
+        return travelPlaces.map(PlaceResponse::from);
     }
 
 }

--- a/src/main/java/com/triptune/domain/schedule/service/ScheduleTravelService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/ScheduleTravelService.java
@@ -1,0 +1,48 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.dto.response.PlaceResponse;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
+import com.triptune.global.util.PageUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleTravelService {
+
+    private final TravelPlaceRepository travelPlaceRepository;
+
+    /**
+     * 중구를 기준으로 여행지 정보 조회
+     * @param page : 페이지 수
+     * @return Page<PlaceResponse>: 여행지 정보로 구성된 페이지 dto
+     */
+    public Page<PlaceResponse> getTravelPlaces(int page) {
+        Pageable pageable = PageUtil.defaultPageable(page);
+
+        return travelPlaceRepository.findAllByAreaData(pageable, "대한민국", "서울", "중구")
+                .map(PlaceResponse::entityToDto);
+
+    }
+
+
+    /**
+     * 여행지 검색
+     * @param page: 페이지 수
+     * @param keyword: 검색 키워드
+     * @return Page<PlaceSimpleResponse>: 여행지 정보로 구성된 페이지 dto
+     */
+    public Page<PlaceResponse> searchTravelPlaces(int page, String keyword) {
+        Pageable pageable = PageUtil.defaultPageable(page);
+        Page<TravelPlace> travelPlaces = travelPlaceRepository.searchTravelPlaces(pageable, keyword);
+
+        return travelPlaces.map(PlaceResponse::entityToDto);
+    }
+
+}

--- a/src/main/java/com/triptune/domain/travel/controller/TravelApiController.java
+++ b/src/main/java/com/triptune/domain/travel/controller/TravelApiController.java
@@ -31,7 +31,7 @@ public class TravelApiController {
 
 
     @PostMapping("/search")
-    @Operation(summary = "여행지 검색", description = "여행지 탐색 메뉴에서 여행지를 검색한다.")
+    @Operation(summary = "여행지 검색", description = "여행지 탐색 메뉴에서 여행지를 검색하며 검색 결과는 현재 위치와 가까운 순으로 제공된다.")
     public ApiPageResponse<PlaceDistanceResponse> searchTravelPlaces(@RequestBody @Valid PlaceSearchRequest placeSearchRequest, @RequestParam int page){
         Page<PlaceDistanceResponse> response = travelService.searchTravelPlaces(placeSearchRequest, page);
         return ApiPageResponse.dataResponse(response);

--- a/src/main/java/com/triptune/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/triptune/domain/travel/controller/TravelController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/travels")
 @Tag(name = "Travel Place", description = "여행지 탐색 관련 API")
 @RequiredArgsConstructor
-public class TravelApiController {
+public class TravelController {
 
     private final TravelService travelService;
 

--- a/src/main/java/com/triptune/domain/travel/dto/response/PlaceDetailResponse.java
+++ b/src/main/java/com/triptune/domain/travel/dto/response/PlaceDetailResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -56,7 +55,7 @@ public class PlaceDetailResponse {
     }
 
 
-    public static PlaceDetailResponse entityToDto(TravelPlace travelPlace){
+    public static PlaceDetailResponse from(TravelPlace travelPlace){
         return PlaceDetailResponse.builder()
                 .placeId(travelPlace.getPlaceId())
                 .placeType(travelPlace.getApiContentType().getContentTypeName())
@@ -75,7 +74,7 @@ public class PlaceDetailResponse {
                 .placeName(travelPlace.getPlaceName())
                 .description(travelPlace.getDescription())
                 .imageList(travelPlace.getTravelImageList().stream()   // TravelImageFile -> TravelImageResponse 로 변경
-                        .map(TravelImageResponse::entityToDto)
+                        .map(TravelImageResponse::from)
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/com/triptune/domain/travel/dto/response/PlaceDistanceResponse.java
+++ b/src/main/java/com/triptune/domain/travel/dto/response/PlaceDistanceResponse.java
@@ -38,7 +38,7 @@ public class PlaceDistanceResponse {
         this.distance = Math.floor(distance * 10) / 10.0;
     }
 
-    public static PlaceDistanceResponse entityToDto(TravelPlace travelPlace){
+    public static PlaceDistanceResponse from(TravelPlace travelPlace){
         return PlaceDistanceResponse.builder()
                 .placeId(travelPlace.getPlaceId())
                 .country(travelPlace.getCountry().getCountryName())
@@ -55,12 +55,12 @@ public class PlaceDistanceResponse {
 
     public static List<PlaceDistanceResponse> entityListToDtoList(List<TravelPlace> travelPlaceList){
         return travelPlaceList.stream()
-                .map(PlaceDistanceResponse::entityToDto)
+                .map(PlaceDistanceResponse::from)
                 .collect(Collectors.toList());
     }
 
 
-    public static PlaceDistanceResponse entityToLocationDto(PlaceLocation placeLocation){
+    public static PlaceDistanceResponse from(PlaceLocation placeLocation){
         return PlaceDistanceResponse.builder()
                 .placeId(placeLocation.getPlaceId())
                 .country(placeLocation.getCountry())

--- a/src/main/java/com/triptune/domain/travel/dto/response/PlaceResponse.java
+++ b/src/main/java/com/triptune/domain/travel/dto/response/PlaceResponse.java
@@ -33,7 +33,7 @@ public class PlaceResponse {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static PlaceResponse entityToDto(TravelPlace travelPlace){
+    public static PlaceResponse from(TravelPlace travelPlace){
         return PlaceResponse.builder()
                 .placeId(travelPlace.getPlaceId())
                 .country(travelPlace.getCountry().getCountryName())

--- a/src/main/java/com/triptune/domain/travel/dto/response/TravelImageResponse.java
+++ b/src/main/java/com/triptune/domain/travel/dto/response/TravelImageResponse.java
@@ -19,7 +19,7 @@ public class TravelImageResponse {
         this.imageUrl = imageUrl;
     }
 
-    public static TravelImageResponse entityToDto(TravelImage travelImage){
+    public static TravelImageResponse from(TravelImage travelImage){
         return TravelImageResponse.builder()
                 .fileId(travelImage.getTravelImageId())
                 .imageName(travelImage.getFileName())

--- a/src/main/java/com/triptune/domain/travel/repository/TravelPlaceCustomRepository.java
+++ b/src/main/java/com/triptune/domain/travel/repository/TravelPlaceCustomRepository.java
@@ -13,5 +13,5 @@ public interface TravelPlaceCustomRepository {
     Page<TravelPlace> searchTravelPlaces(Pageable pageable, String keyword);
     Page<PlaceLocation> findNearByTravelPlaces(Pageable pageable, PlaceLocationRequest placeLocationRequest, int radius);
     Page<PlaceLocation> searchTravelPlacesWithLocation(Pageable pageable, PlaceSearchRequest placeSearchRequest);
-    Integer getTotalElements(BooleanExpression booleanExpression);
+    Integer countTotalElements(BooleanExpression booleanExpression);
 }

--- a/src/main/java/com/triptune/domain/travel/repository/TravelPlaceCustomRepositoryImpl.java
+++ b/src/main/java/com/triptune/domain/travel/repository/TravelPlaceCustomRepositoryImpl.java
@@ -46,7 +46,7 @@ public class TravelPlaceCustomRepositoryImpl implements TravelPlaceCustomReposit
                 .fetch();
 
         // 전체 갯수 조회
-        int totalElements = getTotalElements(expression);
+        int totalElements = countTotalElements(expression);
 
         return new PageImpl<>(content, pageable, totalElements);
     }
@@ -85,7 +85,7 @@ public class TravelPlaceCustomRepositoryImpl implements TravelPlaceCustomReposit
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        int totalElements = getTotalElements(booleanExpression);
+        int totalElements = countTotalElements(booleanExpression);
 
         return PageUtil.createPage(content, pageable, totalElements);
     }
@@ -116,7 +116,7 @@ public class TravelPlaceCustomRepositoryImpl implements TravelPlaceCustomReposit
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        int totalElements = getTotalElements(loeExpression);
+        int totalElements = countTotalElements(loeExpression);
 
         return PageUtil.createPage(content, pageable, totalElements);
     }
@@ -172,14 +172,14 @@ public class TravelPlaceCustomRepositoryImpl implements TravelPlaceCustomReposit
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        int totalElements = getTotalElements(booleanExpression);
+        int totalElements = countTotalElements(booleanExpression);
 
         return PageUtil.createPage(content, pageable, totalElements);
     }
 
 
     @Override
-    public Integer getTotalElements(BooleanExpression expression) {
+    public Integer countTotalElements(BooleanExpression expression) {
         Long totalElements = jpaQueryFactory
                 .select(travelPlace.count())
                 .from(travelPlace)

--- a/src/main/java/com/triptune/domain/travel/repository/TravelPlaceRepository.java
+++ b/src/main/java/com/triptune/domain/travel/repository/TravelPlaceRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface TravelPlacePlaceRepository extends JpaRepository<TravelPlace, Long>, TravelPlaceCustomRepository {
+public interface TravelPlaceRepository extends JpaRepository<TravelPlace, Long>, TravelPlaceCustomRepository {
     Optional<TravelPlace> findByPlaceId(Long placeId);
 }

--- a/src/main/java/com/triptune/domain/travel/service/TravelService.java
+++ b/src/main/java/com/triptune/domain/travel/service/TravelService.java
@@ -43,7 +43,7 @@ public class TravelService {
             }
         }
 
-        return travelPlacePage.map(PlaceDistanceResponse::entityToLocationDto);
+        return travelPlacePage.map(PlaceDistanceResponse::from);
     }
 
     /**
@@ -61,7 +61,7 @@ public class TravelService {
             response.setTravelImageList(travelImageRepository.findByTravelPlacePlaceId(response.getPlaceId()));
         }
 
-        return travelPlacePage.map(PlaceDistanceResponse::entityToLocationDto);
+        return travelPlacePage.map(PlaceDistanceResponse::from);
     }
 
     /**
@@ -73,7 +73,7 @@ public class TravelService {
         TravelPlace travelPlace = travelPlaceRepository.findByPlaceId(placeId)
                 .orElseThrow(()-> new DataNotFoundException(ErrorCode.DATA_NOT_FOUND));
 
-        return PlaceDetailResponse.entityToDto(travelPlace);
+        return PlaceDetailResponse.from(travelPlace);
     }
 
 

--- a/src/main/java/com/triptune/domain/travel/service/TravelService.java
+++ b/src/main/java/com/triptune/domain/travel/service/TravelService.java
@@ -8,13 +8,12 @@ import com.triptune.global.exception.DataNotFoundException;
 import com.triptune.domain.travel.dto.*;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
 import com.triptune.global.util.PageUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -23,7 +22,7 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class TravelService {
 
-    private final TravelPlacePlaceRepository travelPlaceRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
     private final TravelImageRepository travelImageRepository;
 
     private static final int RADIUS_SIZE = 5;

--- a/src/main/java/com/triptune/global/aop/AttendeeCheck.java
+++ b/src/main/java/com/triptune/global/aop/AttendeeCheck.java
@@ -1,0 +1,11 @@
+package com.triptune.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AttendeeCheck {
+}

--- a/src/main/java/com/triptune/global/aop/AttendeeCheckAspect.java
+++ b/src/main/java/com/triptune/global/aop/AttendeeCheckAspect.java
@@ -1,0 +1,53 @@
+package com.triptune.global.aop;
+
+import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import com.triptune.global.exception.DataNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@RequiredArgsConstructor
+@Component
+public class AttendeeCheckAspect {
+
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+    private final HttpServletRequest httpServletRequest;
+
+    @Around("@annotation(AttendeeCheck)")
+    public Object attendeeCheck(ProceedingJoinPoint joinPoint) throws Throwable {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        Long scheduleId = extractScheduleIdFromPath(httpServletRequest.getRequestURI());
+
+        if (!isExistSchedule(scheduleId)){
+            throw new DataNotFoundException(ErrorCode.SCHEDULE_NOT_FOUND);
+        }
+
+        if (!isAttendee(scheduleId, userId)){
+            throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE);
+        }
+
+        return joinPoint.proceed();
+    }
+
+
+    private Long extractScheduleIdFromPath(String path){
+        return Long.parseLong(path.split("/")[3]);
+    }
+
+    private boolean isExistSchedule(Long scheduleId){
+        return travelScheduleRepository.existsById(scheduleId);
+    }
+
+    private boolean isAttendee(Long scheduleId, String userId){
+        return travelAttendeeRepository.existsByTravelSchedule_ScheduleIdAndMember_UserId(scheduleId, userId);
+    }
+}

--- a/src/main/java/com/triptune/global/enumclass/ErrorCode.java
+++ b/src/main/java/com/triptune/global/enumclass/ErrorCode.java
@@ -45,7 +45,10 @@ public enum ErrorCode {
     AUTHOR_NOT_FOUND(HttpStatus.NOT_FOUND, "작성자 정보를 찾을 수 없습니다."),
     FORBIDDEN_ACCESS_SCHEDULE(HttpStatus.FORBIDDEN, "해당 일정에 접근 권한이 없는 사용자 입니다."),
     FORBIDDEN_EDIT_SCHEDULE(HttpStatus.FORBIDDEN, "해당 일정에 편집 권한이 없는 사용자 입니다."),
-    FORBIDDEN_DELETE_SCHEDULE(HttpStatus.FORBIDDEN, "해당 일정에 삭제 권한이 없는 사용자 입니다.");
+    FORBIDDEN_DELETE_SCHEDULE(HttpStatus.FORBIDDEN, "해당 일정에 삭제 권한이 없는 사용자 입니다."),
+
+    // 일정 참석
+    FORBIDDEN_REMOVE_ATTENDEE(HttpStatus.FORBIDDEN, "작성자는 일정에서 나갈 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/triptune/global/response/pagination/SchedulePageResponse.java
+++ b/src/main/java/com/triptune/global/response/pagination/SchedulePageResponse.java
@@ -39,4 +39,15 @@ public class SchedulePageResponse<T> {
                 .content(object.getContent())
                 .build();
     }
+
+    public static <T> SchedulePageResponse<T> of(Page<T> object, int totalElements){
+        return SchedulePageResponse.<T>builder()
+                .totalPages(object.getTotalPages())
+                .currentPage(object.getNumber())
+                .totalElements(totalElements)
+                .totalSharedElements(object.getTotalElements())
+                .pageSize(object.getSize())
+                .content(object.getContent())
+                .build();
+    }
 }

--- a/src/main/java/com/triptune/global/response/pagination/SchedulePageResponse.java
+++ b/src/main/java/com/triptune/global/response/pagination/SchedulePageResponse.java
@@ -29,7 +29,7 @@ public class SchedulePageResponse<T> {
         this.content = content;
     }
 
-    public static <T> SchedulePageResponse<T> of(Page<T> object, long totalSharedElements){
+    public static <T> SchedulePageResponse<T> ofAll(Page<T> object, long totalSharedElements){
         return SchedulePageResponse.<T>builder()
                 .totalPages(object.getTotalPages())
                 .currentPage(object.getNumber())
@@ -40,7 +40,7 @@ public class SchedulePageResponse<T> {
                 .build();
     }
 
-    public static <T> SchedulePageResponse<T> of(Page<T> object, int totalElements){
+    public static <T> SchedulePageResponse<T> ofShared(Page<T> object, int totalElements){
         return SchedulePageResponse.<T>builder()
                 .totalPages(object.getTotalPages())
                 .currentPage(object.getNumber())

--- a/src/test/java/com/triptune/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/triptune/domain/member/controller/MemberControllerTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @Transactional
-public class MemberApiControllerTests {
+public class MemberControllerTest {
 
     @Autowired
     private WebApplicationContext wac;

--- a/src/test/java/com/triptune/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/triptune/domain/member/service/MemberServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 @Transactional
 @Slf4j
-public class MemberServiceTests extends MemberTest {
+public class MemberServiceTest extends MemberTest {
 
     @InjectMocks
     private MemberService memberService;

--- a/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
@@ -1,0 +1,125 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.common.entity.*;
+import com.triptune.domain.common.repository.*;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.member.repository.ProfileImageRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelImageRepository;
+import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class AttendeeControllerTest extends ScheduleTest {
+    private final WebApplicationContext wac;
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+    private final MemberRepository memberRepository;
+
+    private MockMvc mockMvc;
+
+    private Member member1;
+    private Member member2;
+    private Member member3;
+
+    private TravelSchedule schedule1;
+    private TravelSchedule schedule2;
+
+
+    @Autowired
+    public AttendeeControllerTest(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository) {
+        this.wac = wac;
+        this.travelScheduleRepository = travelScheduleRepository;
+        this.travelAttendeeRepository = travelAttendeeRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @BeforeEach
+    void setUp(){
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+
+        member1 = memberRepository.save(createMember(null, "member1"));
+        member2 = memberRepository.save(createMember(null, "member2"));
+        member3 = memberRepository.save(createMember(null, "member3"));
+
+        schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
+        schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
+
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member3, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+    }
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거")
+    @WithMockUser(username = "member2")
+    void removeAttendee() throws Exception {
+        mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule1.getScheduleId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("200(성공)"));
+    }
+
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
+    @WithMockUser(username = "member1")
+    void removeAttendeeIsAuthor_forbiddenScheduleException() throws Exception {
+        mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule1.getScheduleId()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE.getMessage()));
+    }
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 일정에 접근 권한이 없어 예외 발생")
+    @WithMockUser(username = "member1")
+    void removeAttendeeNotAttendee_forbiddenScheduleException() throws Exception {
+        mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule2.getScheduleId()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
+    }
+}

--- a/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
@@ -1,23 +1,14 @@
 package com.triptune.domain.schedule.controller;
 
-import com.triptune.domain.common.entity.*;
-import com.triptune.domain.common.repository.*;
 import com.triptune.domain.member.entity.Member;
-import com.triptune.domain.member.entity.ProfileImage;
 import com.triptune.domain.member.repository.MemberRepository;
-import com.triptune.domain.member.repository.ProfileImageRepository;
 import com.triptune.domain.schedule.ScheduleTest;
 import com.triptune.domain.schedule.entity.TravelAttendee;
 import com.triptune.domain.schedule.entity.TravelSchedule;
 import com.triptune.domain.schedule.enumclass.AttendeePermission;
 import com.triptune.domain.schedule.enumclass.AttendeeRole;
 import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
-import com.triptune.domain.schedule.repository.TravelRouteRepository;
 import com.triptune.domain.schedule.repository.TravelScheduleRepository;
-import com.triptune.domain.travel.entity.TravelImage;
-import com.triptune.domain.travel.entity.TravelPlace;
-import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +24,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -53,13 +43,8 @@ public class AttendeeControllerTest extends ScheduleTest {
 
     private MockMvc mockMvc;
 
-    private Member member1;
-    private Member member2;
-    private Member member3;
-
     private TravelSchedule schedule1;
     private TravelSchedule schedule2;
-
 
     @Autowired
     public AttendeeControllerTest(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository) {
@@ -69,6 +54,7 @@ public class AttendeeControllerTest extends ScheduleTest {
         this.memberRepository = memberRepository;
     }
 
+
     @BeforeEach
     void setUp(){
         mockMvc = MockMvcBuilders.webAppContextSetup(wac)
@@ -77,9 +63,9 @@ public class AttendeeControllerTest extends ScheduleTest {
                 .alwaysDo(print())
                 .build();
 
-        member1 = memberRepository.save(createMember(null, "member1"));
-        member2 = memberRepository.save(createMember(null, "member2"));
-        member3 = memberRepository.save(createMember(null, "member3"));
+        Member member1 = memberRepository.save(createMember(null, "member1"));
+        Member member2 = memberRepository.save(createMember(null, "member2"));
+        Member member3 = memberRepository.save(createMember(null, "member3"));
 
         schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
         schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
@@ -87,7 +73,6 @@ public class AttendeeControllerTest extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
         TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member3, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-
         schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
         schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
     }

--- a/src/test/java/com/triptune/domain/schedule/controller/RouteControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/RouteControllerTest.java
@@ -1,0 +1,199 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.common.entity.*;
+import com.triptune.domain.common.repository.*;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.member.repository.ProfileImageRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelRoute;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelImageRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class RouteControllerTest extends ScheduleTest {
+    private final WebApplicationContext wac;
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+    private final MemberRepository memberRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
+    private final CountryRepository countryRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
+    private final ApiCategoryRepository apiCategoryRepository;
+    private final TravelImageRepository travelImageRepository;
+    private final TravelRouteRepository travelRouteRepository;
+    private final ApiContentTypeRepository apiContentTypeRepository;
+
+    private MockMvc mockMvc;
+
+    private TravelSchedule schedule1;
+    private TravelSchedule schedule2;
+
+    private TravelPlace travelPlace1;
+    private TravelPlace travelPlace2;
+
+
+    @Autowired
+    public RouteControllerTest(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, TravelRouteRepository travelRouteRepository, ApiContentTypeRepository apiContentTypeRepository) {
+        this.wac = wac;
+        this.travelScheduleRepository = travelScheduleRepository;
+        this.travelAttendeeRepository = travelAttendeeRepository;
+        this.memberRepository = memberRepository;
+        this.travelPlaceRepository = travelPlaceRepository;
+        this.countryRepository = countryRepository;
+        this.cityRepository = cityRepository;
+        this.districtRepository = districtRepository;
+        this.apiCategoryRepository = apiCategoryRepository;
+        this.travelImageRepository = travelImageRepository;
+        this.travelRouteRepository = travelRouteRepository;
+        this.apiContentTypeRepository = apiContentTypeRepository;
+    }
+
+    @BeforeEach
+    void setUp(){
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+
+
+
+        Country country = countryRepository.save(createCountry());
+        City city = cityRepository.save(createCity(country));
+        District district1 = districtRepository.save(createDistrict(city, "강남구"));
+        District district2 = districtRepository.save(createDistrict(city, "중구"));
+        ApiCategory apiCategory = apiCategoryRepository.save(createApiCategory());
+        ApiContentType apiContentType = apiContentTypeRepository.save(createApiContentType("관광지"));
+        travelPlace1 = travelPlaceRepository.save(createTravelPlace(null, country, city, district1, apiCategory));
+        travelPlace2 = travelPlaceRepository.save(createTravelPlace(null, country, city, district2, apiCategory));
+        TravelImage travelImage1 = travelImageRepository.save(createTravelImage(travelPlace1, "test1", true));
+        TravelImage travelImage2 = travelImageRepository.save(createTravelImage(travelPlace1, "test2", false));
+        TravelImage travelImage3 = travelImageRepository.save(createTravelImage(travelPlace2, "test1", true));
+        TravelImage travelImage4 = travelImageRepository.save(createTravelImage(travelPlace2, "test2", false));
+        travelPlace1.setApiContentType(apiContentType);
+        travelPlace1.setTravelImageList(Arrays.asList(travelImage1, travelImage2));
+        travelPlace2.setApiContentType(apiContentType);
+        travelPlace2.setTravelImageList(Arrays.asList(travelImage3, travelImage4));
+
+        Member member1 = memberRepository.save(createMember(null, "member1"));
+        Member member2 = memberRepository.save(createMember(null, "member2"));
+
+        schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
+        schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
+
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2, attendee3)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+    }
+
+
+    @Test
+    @DisplayName("getTravelRoutes(): 여행 루트 조회 성공")
+    @WithMockUser(username = "member1")
+    void getTravelRoutes() throws Exception {
+        // given
+        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
+        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 2));
+        TravelRoute route3 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 3));
+
+        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2, route3)));
+        travelPlace1.setTravelRouteList(new ArrayList<>(List.of(route1, route2)));
+        travelPlace2.setTravelRouteList(new ArrayList<>(List.of(route3)));
+
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/routes", schedule1.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andExpect(jsonPath("$.data.content[0].routeOrder").value(route1.getRouteOrder()))
+                .andExpect(jsonPath("$.data.content[0].placeId").value(travelPlace1.getPlaceId()))
+                .andExpect(jsonPath("$.data.content[1].routeOrder").value(route2.getRouteOrder()))
+                .andExpect(jsonPath("$.data.content[1].placeId").value(travelPlace1.getPlaceId()))
+                .andExpect(jsonPath("$.data.content[2].routeOrder").value(route3.getRouteOrder()))
+                .andExpect(jsonPath("$.data.content[2].placeId").value(travelPlace2.getPlaceId()));
+    }
+
+    @Test
+    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 저장된 여행 루트 데이터 없는 경우")
+    @WithMockUser(username = "member1")
+    void getTravelRoutesWithoutData() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/routes", schedule1.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0))
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 일정 데이터 존재하지 않아 예외 발생")
+    @WithMockUser(username = "member1")
+    void getTravelRoutes_dataNotFoundException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/routes", 0L)
+                        .param("page", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 시 해당 일정에 접근 권한이 없어 예외 발생")
+    @WithMockUser(username = "member1")
+    void getTravelRoutes_forbiddenScheduleException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/routes", schedule2.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
+    }
+
+
+
+}

--- a/src/test/java/com/triptune/domain/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/ScheduleControllerTest.java
@@ -21,9 +21,8 @@ import com.triptune.domain.schedule.repository.TravelScheduleRepository;
 import com.triptune.domain.travel.entity.TravelImage;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
-import org.hibernate.sql.Update;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -54,12 +52,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(locations = "classpath:application-test.yml")
-public class ScheduleApiControllerTests extends ScheduleTest {
+public class ScheduleControllerTest extends ScheduleTest {
     private final WebApplicationContext wac;
     private final TravelScheduleRepository travelScheduleRepository;
     private final TravelAttendeeRepository travelAttendeeRepository;
     private final MemberRepository memberRepository;
-    private final TravelPlacePlaceRepository travelPlaceRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
     private final CountryRepository countryRepository;
     private final CityRepository cityRepository;
     private final DistrictRepository districtRepository;
@@ -84,7 +82,7 @@ public class ScheduleApiControllerTests extends ScheduleTest {
 
 
     @Autowired
-    public ScheduleApiControllerTests(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository, TravelPlacePlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, TravelRouteRepository travelRouteRepository, ApiContentTypeRepository apiContentTypeRepository, ProfileImageRepository profileImageRepository) {
+    public ScheduleControllerTest(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, TravelRouteRepository travelRouteRepository, ApiContentTypeRepository apiContentTypeRepository, ProfileImageRepository profileImageRepository) {
         this.wac = wac;
         this.travelScheduleRepository = travelScheduleRepository;
         this.travelAttendeeRepository = travelAttendeeRepository;
@@ -131,44 +129,36 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelImage travelImage3 = travelImageRepository.save(createTravelImage(travelPlace2, "test1", true));
         TravelImage travelImage4 = travelImageRepository.save(createTravelImage(travelPlace2, "test2", false));
         travelPlace1.setApiContentType(apiContentType);
-        travelPlace1.setTravelImageList(Arrays.asList(travelImage1, travelImage2));
+        travelPlace1.setTravelImageList(new ArrayList<>(List.of(travelImage1, travelImage2)));
         travelPlace2.setApiContentType(apiContentType);
-        travelPlace2.setTravelImageList(Arrays.asList(travelImage3, travelImage4));
-
+        travelPlace2.setTravelImageList(new ArrayList<>(List.of(travelImage3, travelImage4)));
 
         schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
         schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
         schedule3 = travelScheduleRepository.save(createTravelSchedule(null,"테스트3"));
-
-
     }
 
     @Test
-    @DisplayName("getSchedules(): 내가 참석한 여행지 목록 조회")
+    @DisplayName("getSchedules(): 전체 일정 목록 조회")
     @WithMockUser(username = "member1")
     void getSchedules() throws Exception {
-        // given
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member3, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
 
         TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
         TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
         TravelRoute route3 = travelRouteRepository.save(createTravelRoute(schedule2, travelPlace1, 1));
         TravelRoute route4 = travelRouteRepository.save(createTravelRoute(schedule2, travelPlace2, 2));
+        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2)));
+        schedule2.setTravelRouteList(new ArrayList<>(List.of(route3, route4)));
 
-        member1.setTravelAttendeeList(List.of(attendee1, attendee2));
-        member2.setTravelAttendeeList(List.of(attendee3));
-        member3.setTravelAttendeeList(List.of(attendee4));
 
-        schedule1.setTravelRouteList(Arrays.asList(route1, route2));
-        schedule2.setTravelRouteList(Arrays.asList(route3, route4));
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee3));
-        schedule2.setTravelAttendeeList(List.of(attendee2));
-        schedule3.setTravelAttendeeList(List.of(attendee4));
-
-        // when, then
         mockMvc.perform(get("/api/schedules")
                 .param("page", "1"))
                 .andExpect(status().isOk())
@@ -181,30 +171,16 @@ public class ScheduleApiControllerTests extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSchedules(): 내가 참석한 여행지 목록 조회 시 여행 루트 데이터가 없는 경우")
-    @WithMockUser(username = "member1")
+    @DisplayName("getSchedules(): 전체 일정 목록 조회 시 여행 루트 데이터가 없는 경우")
+    @WithMockUser(username = "member3")
     void getSchedulesNoRouteData() throws Exception {
-        // given
-        schedule1.setUpdatedAt(LocalDateTime.now().minusDays(3));
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member3, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
 
-        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
-        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member3, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-
-        member1.setTravelAttendeeList(List.of(attendee1, attendee2));
-        member2.setTravelAttendeeList(List.of(attendee3));
-        member3.setTravelAttendeeList(List.of(attendee4));
-
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee3));
-        schedule2.setTravelAttendeeList(List.of(attendee2));
-        schedule3.setTravelAttendeeList(List.of(attendee4));
-
-        // when, then
         mockMvc.perform(get("/api/schedules")
                         .param("page", "1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.totalElements").value(1))
                 .andExpect(jsonPath("$.data.content[0].sinceUpdate").exists())
                 .andExpect(jsonPath("$.data.content[0].scheduleName").exists())
                 .andExpect(jsonPath("$.data.content[0].thumbnailUrl").isEmpty());
@@ -212,15 +188,101 @@ public class ScheduleApiControllerTests extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSchedules(): 내가 참석한 여행지 목록 조회 시 데이터 없는 경우")
+    @DisplayName("getSchedules(): 전체 일정 목록 조회 시 데이터 없는 경우")
     @WithMockUser(username = "member1")
     void getSchedulesWithoutData() throws Exception {
-        // given
-        // when, then
         mockMvc.perform(get("/api/schedules")
                         .param("page", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.totalElements").value(0))
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회")
+    @WithMockUser(username = "member1")
+    void getSharedSchedules() throws Exception {
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
+        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
+        TravelRoute route3 = travelRouteRepository.save(createTravelRoute(schedule2, travelPlace1, 1));
+        TravelRoute route4 = travelRouteRepository.save(createTravelRoute(schedule2, travelPlace2, 2));
+        schedule1.setTravelRouteList(Arrays.asList(route1, route2));
+        schedule2.setTravelRouteList(Arrays.asList(route3, route4));
+
+
+        mockMvc.perform(get("/api/schedules/shared")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andExpect(jsonPath("$.data.totalSharedElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sinceUpdate").exists())
+                .andExpect(jsonPath("$.data.content[0].scheduleName").exists())
+                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").exists())
+                .andExpect(jsonPath("$.data.content[0].role").exists());
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회 시 여행 루트 데이터가 없는 경우")
+    @WithMockUser(username = "member1")
+    void getSharedSchedulesNoRouteData() throws Exception {
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        mockMvc.perform(get("/api/schedules/shared")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andExpect(jsonPath("$.data.totalSharedElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].sinceUpdate").exists())
+                .andExpect(jsonPath("$.data.content[0].scheduleName").exists())
+                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").isEmpty());
+
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회 시 공유된 일정 없는 경우")
+    @WithMockUser(username = "member1")
+    void getSharedSchedulesWithoutSharedData() throws Exception {
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        mockMvc.perform(get("/api/schedules/shared")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(3))
+                .andExpect(jsonPath("$.data.totalSharedElements").value(0))
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회 시 데이터 없는 경우")
+    @WithMockUser(username = "member1")
+    void getSharedSchedulesWithoutData() throws Exception {
+        mockMvc.perform(get("/api/schedules/shared")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0))
+                .andExpect(jsonPath("$.data.totalSharedElements").value(0))
                 .andExpect(jsonPath("$.data.content").isEmpty());
     }
 
@@ -280,8 +342,8 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
-        member1.setTravelAttendeeList(List.of(attendee1, attendee2));
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee2));
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
 
 
         // when, then
@@ -308,8 +370,8 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
         
-        member1.setTravelAttendeeList(List.of(attendee1, attendee2));
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee2));
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
 
 
         // when, then
@@ -324,16 +386,25 @@ public class ScheduleApiControllerTests extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getScheduleDetail(): 일정 조회 시 일정 데이터 존재하지 않아 예외 발생")
+    @DisplayName("getScheduleDetail(): 일정 상세 조회 시 일정 데이터 존재하지 않아 예외 발생")
     @WithMockUser(username = "member1")
     void getScheduleDetail_dataNotFoundException() throws Exception {
-        // given
-        // when, then
         mockMvc.perform(get("/api/schedules/{scheduleId}", 0L)
                         .param("page", "1"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
+    }
+
+
+    @Test
+    @DisplayName("getScheduleDetail(): 일정 상세 조회 시 일정에 접근 권한이 없어 예외 발생")
+    @WithMockUser(username = "member1")
+    void getScheduleDetailNotAttendee_forbiddenScheduleException() throws Exception {
+        mockMvc.perform(delete("/api/schedules/{scheduleId}", schedule2.getScheduleId()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
     }
 
     @Test
@@ -355,7 +426,7 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
         RouteRequest routeRequest2 = createRouteRequest(2, travelPlace2.getPlaceId());
 
-        UpdateScheduleRequest request = createUpdateScheduleRequest(Arrays.asList(routeRequest1, routeRequest2));
+        UpdateScheduleRequest request = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
         // when
         mockMvc.perform(patch("/api/schedules/{scheduleId}", schedule1.getScheduleId())
@@ -377,12 +448,8 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
-
         member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
         member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
-        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2)));
         schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
@@ -414,7 +481,7 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
-        UpdateScheduleRequest request = createUpdateScheduleRequest(List.of(routeRequest1));
+        UpdateScheduleRequest request = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1)));
 
         // when
         mockMvc.perform(patch("/api/schedules/{scheduleId}", schedule1.getScheduleId())
@@ -436,27 +503,20 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
-
-        member1.setTravelAttendeeList(List.of(attendee1));
-        member2.setTravelAttendeeList(List.of(attendee3));
-        schedule1.setTravelRouteList(Arrays.asList(route1, route2));
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee3));
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
-        UpdateScheduleRequest request = createUpdateScheduleRequest(List.of(routeRequest1));
+        UpdateScheduleRequest request = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1)));
 
-        // when
+        // when, then
         mockMvc.perform(patch("/api/schedules/{scheduleId}", schedule1.getScheduleId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJsonString(request)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
 
-        // then
-        assertEquals(schedule1.getScheduleName(), "테스트1");
-        assertEquals(schedule1.getTravelRouteList().size(), 2);
     }
 
 
@@ -468,62 +528,35 @@ public class ScheduleApiControllerTests extends ScheduleTest {
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
         TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
-
-        member1.setTravelAttendeeList(List.of(attendee1));
-        member2.setTravelAttendeeList(List.of(attendee3));
-        schedule1.setTravelRouteList(Arrays.asList(route1, route2));
-        schedule1.setTravelAttendeeList(Arrays.asList(attendee1, attendee3));
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
-        UpdateScheduleRequest request = createUpdateScheduleRequest(List.of(routeRequest1));
+        UpdateScheduleRequest request = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1)));
 
-        // when
+        // when, then
         mockMvc.perform(patch("/api/schedules/{scheduleId}", schedule1.getScheduleId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJsonString(request)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_EDIT_SCHEDULE.getMessage()));
-
-        // then
-        assertEquals(schedule1.getScheduleName(), "테스트1");
-        assertEquals(schedule1.getTravelRouteList().size(), 2);
     }
 
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 성공")
-    @WithMockUser(username = "member1")
-    void getTravelPlaces() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", schedule1.getScheduleId())
-                        .param("page", "1"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
-                .andExpect(jsonPath("$.data.content[0].district").value(travelPlace2.getDistrict().getDistrictName()))
-                .andExpect(jsonPath("$.data.content[0].placeName").value(travelPlace2.getPlaceName()))
-                .andExpect(jsonPath("$.data.content[0].longitude").isNotEmpty())
-                .andExpect(jsonPath("$.data.content[0].latitude").isNotEmpty())
-                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").exists());
-    }
 
     @Test
     @DisplayName("deleteSchedule(): 일정 삭제")
     @WithMockUser(username = "member1")
     void deleteSchedule() throws Exception {
+        // given
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
-
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
         member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
-        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
-        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2)));
-        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
 
+        // when, then
         mockMvc.perform(delete("/api/schedules/{scheduleId}", schedule1.getScheduleId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true));
@@ -534,157 +567,21 @@ public class ScheduleApiControllerTests extends ScheduleTest {
     @DisplayName("deleteSchedule(): 일정 삭제 시 삭제 권한이 없는 사용자 요청으로 예외 발생")
     @WithMockUser(username = "member2")
     void deleteSchedule_forbiddenScheduleException() throws Exception {
+        // given
         TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
-        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
-
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 2));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
 
         member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
-        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
-        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2)));
-        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee3)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
 
+        // when, then
         mockMvc.perform(delete("/api/schedules/{scheduleId}", schedule1.getScheduleId()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_DELETE_SCHEDULE.getMessage()));
 
     }
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 시 여행지 데이터 존재하지 않는 경우")
-    @WithMockUser(username = "member1")
-    void getTravelPlacesWithoutData() throws Exception {
-        // given
-        travelPlaceRepository.deleteAll();
-        
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", schedule1.getScheduleId())
-                        .param("page", "1"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(0))
-                .andExpect(jsonPath("$.data.content").isEmpty());
-    }
-
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 시 일정 데이터 존재하지 않아 예외 발생")
-    @WithMockUser(username = "member1")
-    void getTravelPlaces_dataNotFoundException() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", 0L)
-                        .param("page", "1"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
-    }
-
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 성공")
-    @WithMockUser(username = "member1")
-    void searchTravelPlaces() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", schedule1.getScheduleId())
-                        .param("page", "1")
-                        .param("keyword", "강남"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(1))
-                .andExpect(jsonPath("$.data.content[0].district").value(travelPlace1.getDistrict().getDistrictName()))
-                .andExpect(jsonPath("$.data.content[0].placeName").value(travelPlace1.getPlaceName()))
-                .andExpect(jsonPath("$.data.content[0].longitude").isNotEmpty())
-                .andExpect(jsonPath("$.data.content[0].latitude").isNotEmpty())
-                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").exists());
-    }
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 시 검색 결과가 존재하지 않는 경우")
-    @WithMockUser(username = "member1")
-    void searchTravelPlacesWithoutData() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", schedule1.getScheduleId())
-                        .param("page", "1")
-                        .param("keyword", "ㅁㄴㅇㄹ"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(0))
-                .andExpect(jsonPath("$.data.content").isEmpty());
-    }
-
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 시 일정 데이터 존재하지 않아 예외 발생")
-    @WithMockUser(username = "member1")
-    void searchTravelPlaces_dataNotFoundException() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", 0L)
-                        .param("page", "1")
-                        .param("keyword", "ㅁㄴㅇㄹ"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 성공")
-    @WithMockUser(username = "member1")
-    void getTravelRoutes() throws Exception {
-        // given
-        TravelRoute route1 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 1));
-        TravelRoute route2 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace1, 2));
-        TravelRoute route3 = travelRouteRepository.save(createTravelRoute(schedule1, travelPlace2, 3));
-
-        List<TravelRoute> travelRouteListAll = Arrays.asList(route1, route2, route3);
-        List<TravelRoute> travelRouteList1 = Arrays.asList(route1, route2);
-        List<TravelRoute> travelRouteList2 = List.of(route3);
-
-        schedule1.setTravelRouteList(travelRouteListAll);
-        travelPlace1.setTravelRouteList(travelRouteList1);
-        travelPlace2.setTravelRouteList(travelRouteList2);
-
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/routes", schedule1.getScheduleId())
-                        .param("page", "1"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.totalElements").value(3))
-                .andExpect(jsonPath("$.data.content[0].routeOrder").value(route1.getRouteOrder()))
-                .andExpect(jsonPath("$.data.content[0].placeId").value(travelPlace1.getPlaceId()))
-                .andExpect(jsonPath("$.data.content[1].routeOrder").value(route2.getRouteOrder()))
-                .andExpect(jsonPath("$.data.content[1].placeId").value(travelPlace1.getPlaceId()))
-                .andExpect(jsonPath("$.data.content[2].routeOrder").value(route3.getRouteOrder()))
-                .andExpect(jsonPath("$.data.content[2].placeId").value(travelPlace2.getPlaceId()));
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 저장된 여행 루트 데이터 없는 경우")
-    @WithMockUser(username = "member1")
-    void getTravelRoutesWithoutData() throws Exception {
-        // given
-        // when, then
-         mockMvc.perform(get("/api/schedules/{scheduleId}/routes", schedule1.getScheduleId())
-                                .param("page", "1"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data.totalElements").value(0))
-                        .andExpect(jsonPath("$.data.content").isEmpty());
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 일정 데이터 존재하지 않아 예외 발생")
-    @WithMockUser(username = "member1")
-    void getTravelRoutes_dataNotFoundException() throws Exception {
-        // given
-        // when, then
-        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", 0L)
-                        .param("page", "1"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
-    }
-
 
 
 }

--- a/src/test/java/com/triptune/domain/schedule/controller/ScheduleTravelControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/ScheduleTravelControllerTest.java
@@ -1,0 +1,253 @@
+package com.triptune.domain.schedule.controller;
+
+import com.triptune.domain.BaseTest;
+import com.triptune.domain.common.entity.*;
+import com.triptune.domain.common.repository.*;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.member.repository.ProfileImageRepository;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelImageRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class ScheduleTravelControllerTest extends BaseTest {
+
+    private final WebApplicationContext wac;
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+    private final MemberRepository memberRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
+    private final CountryRepository countryRepository;
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
+    private final ApiCategoryRepository apiCategoryRepository;
+    private final TravelImageRepository travelImageRepository;
+    private final ApiContentTypeRepository apiContentTypeRepository;
+
+    private MockMvc mockMvc;
+
+    private TravelSchedule schedule1;
+    private TravelSchedule schedule2;
+
+    private TravelPlace travelPlace1;
+    private TravelPlace travelPlace2;
+
+
+    @Autowired
+    public ScheduleTravelControllerTest(WebApplicationContext wac, TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
+        this.wac = wac;
+        this.travelScheduleRepository = travelScheduleRepository;
+        this.travelAttendeeRepository = travelAttendeeRepository;
+        this.memberRepository = memberRepository;
+        this.travelPlaceRepository = travelPlaceRepository;
+        this.countryRepository = countryRepository;
+        this.cityRepository = cityRepository;
+        this.districtRepository = districtRepository;
+        this.apiCategoryRepository = apiCategoryRepository;
+        this.travelImageRepository = travelImageRepository;
+        this.apiContentTypeRepository = apiContentTypeRepository;
+    }
+
+    @BeforeEach
+    void setUp(){
+        mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+
+        Country country = countryRepository.save(createCountry());
+        City city = cityRepository.save(createCity(country));
+        District district1 = districtRepository.save(createDistrict(city, "강남구"));
+        District district2 = districtRepository.save(createDistrict(city, "중구"));
+        ApiCategory apiCategory = apiCategoryRepository.save(createApiCategory());
+        ApiContentType apiContentType = apiContentTypeRepository.save(createApiContentType("관광지"));
+        travelPlace1 = travelPlaceRepository.save(createTravelPlace(null, country, city, district1, apiCategory));
+        travelPlace2 = travelPlaceRepository.save(createTravelPlace(null, country, city, district2, apiCategory));
+        TravelImage travelImage1 = travelImageRepository.save(createTravelImage(travelPlace1, "test1", true));
+        TravelImage travelImage2 = travelImageRepository.save(createTravelImage(travelPlace1, "test2", false));
+        TravelImage travelImage3 = travelImageRepository.save(createTravelImage(travelPlace2, "test1", true));
+        TravelImage travelImage4 = travelImageRepository.save(createTravelImage(travelPlace2, "test2", false));
+        travelPlace1.setApiContentType(apiContentType);
+        travelPlace1.setTravelImageList(Arrays.asList(travelImage1, travelImage2));
+        travelPlace2.setApiContentType(apiContentType);
+        travelPlace2.setTravelImageList(Arrays.asList(travelImage3, travelImage4));
+
+        Member member1 = memberRepository.save(createMember(null, "member1"));
+        Member member2 = memberRepository.save(createMember(null, "member2"));
+
+        schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
+        schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
+
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2, attendee3)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+    }
+
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 성공")
+    @WithMockUser(username = "member1")
+    void getTravelPlaces() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", schedule1.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].district").value(travelPlace2.getDistrict().getDistrictName()))
+                .andExpect(jsonPath("$.data.content[0].placeName").value(travelPlace2.getPlaceName()))
+                .andExpect(jsonPath("$.data.content[0].longitude").isNotEmpty())
+                .andExpect(jsonPath("$.data.content[0].latitude").isNotEmpty())
+                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").exists());
+    }
+
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 시 여행지 데이터 존재하지 않는 경우")
+    @WithMockUser(username = "member1")
+    void getTravelPlacesWithoutData() throws Exception {
+        // given
+        travelPlaceRepository.deleteAll();
+
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", schedule1.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0))
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 시 해당 일정에 접근 권한이 없어 예외 발생")
+    @WithMockUser(username = "member1")
+    void getTravelPlaces_forbiddenScheduleException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", schedule2.getScheduleId())
+                        .param("page", "1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
+    }
+
+
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 시 일정 데이터 존재하지 않아 예외 발생")
+    @WithMockUser(username = "member1")
+    void getTravelPlaces_dataNotFoundException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels", 0L)
+                        .param("page", "1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
+    }
+
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 성공")
+    @WithMockUser(username = "member1")
+    void searchTravelPlaces() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", schedule1.getScheduleId())
+                        .param("page", "1")
+                        .param("keyword", "강남"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.content[0].district").value(travelPlace1.getDistrict().getDistrictName()))
+                .andExpect(jsonPath("$.data.content[0].placeName").value(travelPlace1.getPlaceName()))
+                .andExpect(jsonPath("$.data.content[0].longitude").isNotEmpty())
+                .andExpect(jsonPath("$.data.content[0].latitude").isNotEmpty())
+                .andExpect(jsonPath("$.data.content[0].thumbnailUrl").exists());
+    }
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 시 검색 결과가 존재하지 않는 경우")
+    @WithMockUser(username = "member1")
+    void searchTravelPlacesWithoutData() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", schedule1.getScheduleId())
+                        .param("page", "1")
+                        .param("keyword", "ㅁㄴㅇㄹ"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0))
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 시 일정 데이터 존재하지 않아 예외 발생")
+    @WithMockUser(username = "member1")
+    void searchTravelPlaces_dataNotFoundException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", 0L)
+                        .param("page", "1")
+                        .param("keyword", "ㅁㄴㅇㄹ"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.SCHEDULE_NOT_FOUND.getMessage()));
+    }
+
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 시 해당 일정에 접근 권한이 없어 예외 발생")
+    @WithMockUser(username = "member1")
+    void searchTravelPlaces_forbiddenScheduleException() throws Exception {
+        // given
+        // when, then
+        mockMvc.perform(get("/api/schedules/{scheduleId}/travels/search", schedule2.getScheduleId())
+                        .param("page", "1")
+                        .param("keyword", "중구"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage()));
+    }
+
+
+}

--- a/src/test/java/com/triptune/domain/schedule/repository/TravelAttendeeRepositoryTest.java
+++ b/src/test/java/com/triptune/domain/schedule/repository/TravelAttendeeRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.triptune.domain.schedule.repository;
+
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.global.config.QueryDSLConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Import({QueryDSLConfig.class})
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class TravelAttendeeRepositoryTest extends ScheduleTest {
+    private final TravelScheduleRepository travelScheduleRepository;
+    private final TravelAttendeeRepository travelAttendeeRepository;
+    private final MemberRepository memberRepository;
+
+    private TravelSchedule schedule1;
+    private TravelSchedule schedule2;
+    private TravelSchedule schedule3;
+    private Member member1;
+    private Member member2;
+
+
+    @Autowired
+    public TravelAttendeeRepositoryTest(TravelScheduleRepository travelScheduleRepository, TravelAttendeeRepository travelAttendeeRepository, MemberRepository memberRepository) {
+        this.travelScheduleRepository = travelScheduleRepository;
+        this.travelAttendeeRepository = travelAttendeeRepository;
+        this.memberRepository = memberRepository;
+    }
+
+
+    @BeforeEach
+    void setUp(){
+        member1 = memberRepository.save(createMember(null, "member1"));
+        member2 = memberRepository.save(createMember(null, "member2"));
+
+        schedule1 = travelScheduleRepository.save(createTravelSchedule(null,"테스트1"));
+        schedule2 = travelScheduleRepository.save(createTravelSchedule(null,"테스트2"));
+        schedule3 = travelScheduleRepository.save(createTravelSchedule(null,"테스트3"));
+
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+    }
+
+    @Test
+    @DisplayName("일정 참가자인지 확인 true 반환")
+    void existsAttendee_true(){
+        // when
+        boolean response = travelAttendeeRepository.existsByTravelSchedule_ScheduleIdAndMember_UserId(schedule1.getScheduleId(), member1.getUserId());
+
+        // then
+        assertTrue(response);
+    }
+
+    @Test
+    @DisplayName("일정 참가자인지 확인 false 반환")
+    void existsAttendee_false(){
+        // when
+        boolean response = travelAttendeeRepository.existsByTravelSchedule_ScheduleIdAndMember_UserId(schedule1.getScheduleId(), member2.getUserId());
+
+        // then
+        assertFalse(response);
+    }
+
+
+    @Test
+    @DisplayName("일정 참가자인지 확인 false 반환")
+    void existsAttendee_fals(){
+        // when
+        boolean response = travelAttendeeRepository.existsByTravelSchedule_ScheduleIdAndMember_UserId(0L, member2.getUserId());
+
+        // then
+        assertFalse(response);
+    }
+}

--- a/src/test/java/com/triptune/domain/schedule/repository/TravelScheduleRepositoryTest.java
+++ b/src/test/java/com/triptune/domain/schedule/repository/TravelScheduleRepositoryTest.java
@@ -252,6 +252,163 @@ public class TravelScheduleRepositoryTest extends ScheduleTest {
     }
 
     @Test
+    @DisplayName("searchTravelSchedulesByUserId(): 전체 일정 목록 중 검색")
+    void searchTravelSchedulesByUserId(){
+        // given
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule2, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        attendee4.getTravelSchedule().setScheduleName("테스트23");
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3, attendee4)));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2, attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        // when
+        Page<TravelSchedule> response = travelScheduleRepository.searchTravelSchedulesByUserIdAndKeyword(pageable, "2", member1.getUserId());
+
+        // then
+        List<TravelSchedule> content = response.getContent();
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(content.get(0).getScheduleName()).isEqualTo(schedule2.getScheduleName());
+        assertThat(content.get(0).getStartDate()).isEqualTo(schedule2.getStartDate());
+
+    }
+
+    @Test
+    @DisplayName("searchTravelSchedulesByUserId(): 전체 일정 목록 검색 시 데이터가 없는 경우")
+    void searchTravelSchedulesByUserIdWithoutData(){
+        // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        // when
+        Page<TravelSchedule> response = travelScheduleRepository.searchTravelSchedulesByUserIdAndKeyword(pageable, "ㅁㄴㅇㄹ", member1.getUserId());
+
+        // then
+        assertThat(response.getTotalElements()).isEqualTo(0);
+        assertThat(response.getContent().isEmpty()).isTrue();
+
+    }
+
+
+    @Test
+    @DisplayName("searchSharedTravelSchedulesByUserIdAndKeyword(): 공유된 일정 목록 검색")
+    void searchSharedTravelSchedulesByUserIdAndKeyword(){
+        // given
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule2, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3, attendee4)));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2, attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        // when
+        Page<TravelSchedule> response = travelScheduleRepository.searchSharedTravelSchedulesByUserIdAndKeyword(pageable, "2", member1.getUserId());
+
+        // then
+        List<TravelSchedule> content = response.getContent();
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(content.get(0).getScheduleName()).isEqualTo(schedule2.getScheduleName());
+        assertThat(content.get(0).getStartDate()).isEqualTo(schedule2.getStartDate());
+
+    }
+
+    @Test
+    @DisplayName("searchSharedTravelSchedulesByUserIdAndKeyword(): 공유된 일정 목록 검색 시 데이터가 없는 경우")
+    void searchSharedTravelSchedulesByUserIdAndKeywordWithoutData(){
+        // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        // when
+        Page<TravelSchedule> response = travelScheduleRepository.searchSharedTravelSchedulesByUserIdAndKeyword(pageable, "ㅁㄴㅇㄹ", member1.getUserId());
+
+        // then
+        assertThat(response.getTotalElements()).isEqualTo(0);
+        assertThat(response.getContent().isEmpty()).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("countTravelSchedulesByUserIdAndKeyword(): 전체 일정 키워드 검색 갯수 조회")
+    void countTravelSchedulesByUserIdAndKeyword(){
+        // given
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.READ));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee3)));
+
+        // when
+        Integer response = travelScheduleRepository.countTravelSchedulesByUserIdAndKeyword("2", member1.getUserId());
+
+        // then
+        assertEquals(response, 1);
+    }
+
+    @Test
+    @DisplayName("countTravelSchedulesByUserIdAndKeyword(): 일정 갯수 키워드 검색 시 데이터가 없는 경우")
+    void countTravelSchedulesByUserIdAndKeywordWithoutData(){
+        // given
+        // when
+        Integer response = travelScheduleRepository.countTravelSchedulesByUserIdAndKeyword("ㅁㄴㅇㄹ", member1.getUserId());
+
+        // then
+        assertEquals(response, 0);
+    }
+
+    @Test
+    @DisplayName("countSharedTravelSchedulesByUserIdAndKeyword(): 공유된 일정 키워드 검색 갯수 조회")
+    void countSharedTravelSchedulesByUserIdAndKeyword(){
+        // given
+        TravelAttendee attendee1 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee2 = travelAttendeeRepository.save(createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+        TravelAttendee attendee3 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule2, AttendeeRole.GUEST, AttendeePermission.READ));
+        TravelAttendee attendee4 = travelAttendeeRepository.save(createTravelAttendee(member2, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL));
+
+        member1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        member2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3, attendee4)));
+
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee2, attendee3)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+
+        // when
+        Integer response = travelScheduleRepository.countSharedTravelSchedulesByUserIdAndKeyword("2", member1.getUserId());
+
+        // then
+        assertEquals(response, 1);
+    }
+
+    @Test
+    @DisplayName("countSharedTravelSchedulesByUserIdAndKeyword(): 공유된 일정 키워드 검색 갯수 조회 시 데이터가 없는 경우")
+    void countSharedTravelSchedulesByUserIdAndKeywordWithoutData(){
+        // given
+        // when
+        Integer response = travelScheduleRepository.countSharedTravelSchedulesByUserIdAndKeyword("ㅁㄴㅇㄹ", member1.getUserId());
+
+        // then
+        assertEquals(response, 0);
+    }
+
+    @Test
     @DisplayName("deleteById(): 일정 삭제")
     void deleteById(){
         // given

--- a/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
@@ -1,22 +1,13 @@
 package com.triptune.domain.schedule.service;
 
-import com.triptune.domain.common.entity.ApiCategory;
-import com.triptune.domain.common.entity.City;
-import com.triptune.domain.common.entity.Country;
-import com.triptune.domain.common.entity.District;
 import com.triptune.domain.member.entity.Member;
-import com.triptune.domain.member.entity.ProfileImage;
 import com.triptune.domain.schedule.ScheduleTest;
 import com.triptune.domain.schedule.entity.TravelAttendee;
-import com.triptune.domain.schedule.entity.TravelRoute;
 import com.triptune.domain.schedule.entity.TravelSchedule;
 import com.triptune.domain.schedule.enumclass.AttendeePermission;
 import com.triptune.domain.schedule.enumclass.AttendeeRole;
 import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
 import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
-import com.triptune.domain.schedule.repository.TravelScheduleRepository;
-import com.triptune.domain.travel.entity.TravelImage;
-import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.global.enumclass.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -41,32 +32,28 @@ public class AttendeeServiceTest extends ScheduleTest {
     private AttendeeService attendeeService;
 
     @Mock
-    private TravelScheduleRepository travelScheduleRepository;
-
-    @Mock
     private TravelAttendeeRepository travelAttendeeRepository;
 
     private TravelSchedule schedule1;
-    private TravelSchedule schedule2;
     private Member member1;
     private Member member2;
-    private Member member3;
-    private TravelAttendee attentee1;
+    private TravelAttendee attendee1;
+    private TravelAttendee attendee2;
 
     @BeforeEach
     void setUp(){
         member1 = createMember(1L, "member1");
         member2 = createMember(2L, "member2");
-        member3 = createMember(3L, "member3");
+        Member member3 = createMember(3L, "member3");
 
         schedule1 = createTravelSchedule(1L, "테스트1");
-        schedule2 = createTravelSchedule(2L, "테스트2");
+        TravelSchedule schedule2 = createTravelSchedule(2L, "테스트2");
 
-        attentee1 = createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL);
-        TravelAttendee attendee2 = createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ);
+        attendee1 = createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        attendee2 = createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ);
         TravelAttendee attendee3 = createTravelAttendee(member3, schedule1, AttendeeRole.GUEST, AttendeePermission.CHAT);
         TravelAttendee attendee4 = createTravelAttendee(member3, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL);
-        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attentee1, attendee2, attendee3)));
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2, attendee3)));
         schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
     }
 
@@ -74,7 +61,7 @@ public class AttendeeServiceTest extends ScheduleTest {
     @DisplayName("removeAttendee(): 일정 참석자 제거")
     void removeAttendee(){
         // given
-        when(travelScheduleRepository.findByScheduleId(schedule1.getScheduleId())).thenReturn(Optional.of(schedule1));
+        when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee2));
 
         // when
         attendeeService.removeAttendee(schedule1.getScheduleId(), member2.getUserId());
@@ -83,12 +70,25 @@ public class AttendeeServiceTest extends ScheduleTest {
         verify(travelAttendeeRepository, times(1)).deleteById(any());
     }
 
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거 시 참가자 정보가 없어 예외 발생")
+    void removeAttendeeNoAttendeeData_forbiddenScheduleException(){
+        // given
+        when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.empty());
+
+        // when
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule1.getScheduleId(), member1.getUserId()));
+
+        // then
+        assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
+        assertThat(fail.getMessage()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage());
+    }
 
     @Test
     @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
     void removeAttendeeIsAuthor_forbiddenScheduleException(){
         // given
-        when(travelScheduleRepository.findByScheduleId(schedule1.getScheduleId())).thenReturn(Optional.of(schedule1));
+        when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee1));
 
         // when
         ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule1.getScheduleId(), member1.getUserId()));
@@ -98,17 +98,4 @@ public class AttendeeServiceTest extends ScheduleTest {
         assertThat(fail.getMessage()).isEqualTo(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE.getMessage());
     }
 
-    @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 일정에 접근 권한이 없어 예외 발생")
-    void removeAttendeeNotAttendee_forbiddenScheduleException(){
-        // given
-        when(travelScheduleRepository.findByScheduleId(schedule2.getScheduleId())).thenReturn(Optional.of(schedule2));
-
-        // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule2.getScheduleId(), member1.getUserId()));
-
-        // then
-        assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
-        assertThat(fail.getMessage()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage());
-    }
 }

--- a/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
@@ -1,0 +1,114 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.common.entity.ApiCategory;
+import com.triptune.domain.common.entity.City;
+import com.triptune.domain.common.entity.Country;
+import com.triptune.domain.common.entity.District;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelRoute;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.global.enumclass.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AttendeeServiceTest extends ScheduleTest {
+    @InjectMocks
+    private AttendeeService attendeeService;
+
+    @Mock
+    private TravelScheduleRepository travelScheduleRepository;
+
+    @Mock
+    private TravelAttendeeRepository travelAttendeeRepository;
+
+    private TravelSchedule schedule1;
+    private TravelSchedule schedule2;
+    private Member member1;
+    private Member member2;
+    private Member member3;
+    private TravelAttendee attentee1;
+
+    @BeforeEach
+    void setUp(){
+        member1 = createMember(1L, "member1");
+        member2 = createMember(2L, "member2");
+        member3 = createMember(3L, "member3");
+
+        schedule1 = createTravelSchedule(1L, "테스트1");
+        schedule2 = createTravelSchedule(2L, "테스트2");
+
+        attentee1 = createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        TravelAttendee attendee2 = createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ);
+        TravelAttendee attendee3 = createTravelAttendee(member3, schedule1, AttendeeRole.GUEST, AttendeePermission.CHAT);
+        TravelAttendee attendee4 = createTravelAttendee(member3, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attentee1, attendee2, attendee3)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+    }
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거")
+    void removeAttendee(){
+        // given
+        when(travelScheduleRepository.findByScheduleId(schedule1.getScheduleId())).thenReturn(Optional.of(schedule1));
+
+        // when
+        attendeeService.removeAttendee(schedule1.getScheduleId(), member2.getUserId());
+
+        // then
+        verify(travelAttendeeRepository, times(1)).deleteById(any());
+    }
+
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
+    void removeAttendeeIsAuthor_forbiddenScheduleException(){
+        // given
+        when(travelScheduleRepository.findByScheduleId(schedule1.getScheduleId())).thenReturn(Optional.of(schedule1));
+
+        // when
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule1.getScheduleId(), member1.getUserId()));
+
+        // then
+        assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE.getStatus());
+        assertThat(fail.getMessage()).isEqualTo(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE.getMessage());
+    }
+
+    @Test
+    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 일정에 접근 권한이 없어 예외 발생")
+    void removeAttendeeNotAttendee_forbiddenScheduleException(){
+        // given
+        when(travelScheduleRepository.findByScheduleId(schedule2.getScheduleId())).thenReturn(Optional.of(schedule2));
+
+        // when
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule2.getScheduleId(), member1.getUserId()));
+
+        // then
+        assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
+        assertThat(fail.getMessage()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getMessage());
+    }
+}

--- a/src/test/java/com/triptune/domain/schedule/service/RouteServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/RouteServiceTest.java
@@ -1,0 +1,125 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.common.entity.ApiCategory;
+import com.triptune.domain.common.entity.City;
+import com.triptune.domain.common.entity.Country;
+import com.triptune.domain.common.entity.District;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.dto.response.RouteResponse;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelRoute;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import com.triptune.global.exception.DataNotFoundException;
+import com.triptune.global.util.PageUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RouteServiceTest extends ScheduleTest {
+
+    @InjectMocks
+    private RouteService routeService;
+
+    @Mock
+    private TravelRouteRepository travelRouteRepository;
+
+    private TravelSchedule schedule1;
+    private TravelPlace travelPlace1;
+
+    @BeforeEach
+    void setUp(){
+        Country country = createCountry();
+        City city = createCity(country);
+        District district = createDistrict(city, "중구");
+        ApiCategory apiCategory = createApiCategory();
+        travelPlace1 = createTravelPlace(1L, country, city, district, apiCategory);
+        TravelImage travelImage1 = createTravelImage(travelPlace1, "test1", true);
+        TravelImage travelImage2 = createTravelImage(travelPlace1, "test2", false);
+        List<TravelImage> travelImageList1 = new ArrayList<>(List.of(travelImage1, travelImage2));
+        travelPlace1.setTravelImageList(travelImageList1);
+
+        TravelPlace travelPlace2 = createTravelPlace(2L, country, city, district, apiCategory);
+        TravelImage travelImage3 = createTravelImage(travelPlace2, "test1", true);
+        TravelImage travelImage4 = createTravelImage(travelPlace2, "test2", false);
+        List<TravelImage> travelImageList2 = new ArrayList<>(List.of(travelImage3, travelImage4));
+        travelPlace2.setTravelImageList(travelImageList2);
+
+        schedule1 = createTravelSchedule(1L, "테스트1");
+
+        TravelRoute route1 = createTravelRoute(schedule1, travelPlace1, 1);
+        TravelRoute route2 = createTravelRoute(schedule1, travelPlace1, 2);
+        TravelRoute route3 = createTravelRoute(schedule1, travelPlace2, 3);
+        schedule1.setTravelRouteList(new ArrayList<>(List.of(route1, route2, route3)));
+    }
+
+
+
+    @Test
+    @DisplayName("getTravelRoutes(): 여행 루트 조회 성공")
+    void getTravelRoutes(){
+        // given
+        Pageable pageable = PageUtil.defaultPageable(1);
+
+        when(travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, schedule1.getScheduleId()))
+                .thenReturn(PageUtil.createPage(schedule1.getTravelRouteList(), pageable, schedule1.getTravelRouteList().size()));
+
+
+        // when
+        Page<RouteResponse> response = routeService.getTravelRoutes(schedule1.getScheduleId(), 1);
+
+        // then
+        List<RouteResponse> content = response.getContent();
+        assertEquals(response.getTotalElements(), schedule1.getTravelRouteList().size());
+        assertEquals(content.get(0).getAddress(), travelPlace1.getAddress());
+        assertEquals(content.get(0).getRouteOrder(), schedule1.getTravelRouteList().get(0).getRouteOrder());
+        assertEquals(content.get(1).getRouteOrder(), schedule1.getTravelRouteList().get(1).getRouteOrder());
+        assertEquals(content.get(2).getRouteOrder(), schedule1.getTravelRouteList().get(2).getRouteOrder());
+    }
+
+    @Test
+    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 저장된 여행 루트 데이터 없는 경우")
+    void getTravelRoutesWithoutData(){
+        // given
+        Pageable pageable = PageUtil.defaultPageable(1);
+
+        when(travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, schedule1.getScheduleId()))
+                .thenReturn(PageUtil.createPage(new ArrayList<>(), pageable, 0));
+
+
+        // when
+        Page<RouteResponse> response = routeService.getTravelRoutes(schedule1.getScheduleId(), 1);
+
+        // then
+        assertEquals(response.getTotalElements(), 0);
+        assertTrue(response.getContent().isEmpty());
+    }
+
+}

--- a/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
@@ -10,7 +10,6 @@ import com.triptune.domain.schedule.dto.request.CreateScheduleRequest;
 import com.triptune.domain.schedule.dto.request.RouteRequest;
 import com.triptune.domain.schedule.dto.request.UpdateScheduleRequest;
 import com.triptune.domain.schedule.dto.response.CreateScheduleResponse;
-import com.triptune.domain.schedule.dto.response.RouteResponse;
 import com.triptune.domain.schedule.dto.response.ScheduleDetailResponse;
 import com.triptune.domain.schedule.dto.response.ScheduleInfoResponse;
 import com.triptune.domain.schedule.entity.TravelAttendee;
@@ -22,10 +21,9 @@ import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
 import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
 import com.triptune.domain.schedule.repository.TravelRouteRepository;
 import com.triptune.domain.schedule.repository.TravelScheduleRepository;
-import com.triptune.domain.travel.dto.response.PlaceResponse;
 import com.triptune.domain.travel.entity.TravelImage;
 import com.triptune.domain.travel.entity.TravelPlace;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
 import com.triptune.global.exception.DataNotFoundException;
 import com.triptune.global.response.pagination.SchedulePageResponse;
@@ -50,7 +48,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class ScheduleServiceTests extends ScheduleTest {
+public class ScheduleServiceTest extends ScheduleTest {
 
     @InjectMocks
     private ScheduleService scheduleService;
@@ -65,19 +63,20 @@ public class ScheduleServiceTests extends ScheduleTest {
     private TravelAttendeeRepository travelAttendeeRepository;
 
     @Mock
-    private TravelPlacePlaceRepository travelPlaceRepository;
+    private TravelPlaceRepository travelPlaceRepository;
 
     @Mock
     private TravelRouteRepository travelRouteRepository;
 
     private TravelSchedule schedule1;
     private TravelSchedule schedule2;
+    private TravelSchedule schedule3;
     private TravelPlace travelPlace1;
     private TravelPlace travelPlace2;
     private Member member1;
     private Member member2;
-    private Member member3;
-    private TravelAttendee attentee1;
+    private TravelAttendee attendee1;
+    private TravelAttendee attendee2;
 
     @BeforeEach
     void setUp(){
@@ -99,23 +98,24 @@ public class ScheduleServiceTests extends ScheduleTest {
 
         member1 = createMember(1L, "member1");
         member2 = createMember(2L, "member2");
-        member3 = createMember(3L, "member3");
         ProfileImage member1Image = createProfileImage(1L, "member1Image");
         ProfileImage member2Image = createProfileImage(2L, "member2Image");
         ProfileImage member3Image = createProfileImage(3L, "member3Image");
         member1.setProfileImage(member1Image);
         member2.setProfileImage(member2Image);
-        member3.setProfileImage(member3Image);
 
         schedule1 = createTravelSchedule(1L, "테스트1");
         schedule2 = createTravelSchedule(2L, "테스트2");
+        schedule3 = createTravelSchedule(3L, "테스트3");
 
-        attentee1 = createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL);
-        TravelAttendee attendee2 = createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ);
-        TravelAttendee attendee3 = createTravelAttendee(member3, schedule1, AttendeeRole.GUEST, AttendeePermission.CHAT);
-        TravelAttendee attendee4 = createTravelAttendee(member3, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL);
-        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attentee1, attendee2, attendee3)));
-        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee4)));
+        attendee1 = createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        attendee2 = createTravelAttendee(member2, schedule1, AttendeeRole.GUEST, AttendeePermission.READ);
+        TravelAttendee attendee3 = createTravelAttendee(member1, schedule2, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        TravelAttendee attendee4 = createTravelAttendee(member2, schedule2, AttendeeRole.GUEST, AttendeePermission.CHAT);
+        TravelAttendee attendee5 = createTravelAttendee(member1, schedule3, AttendeeRole.AUTHOR, AttendeePermission.ALL);
+        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(attendee1, attendee2)));
+        schedule2.setTravelAttendeeList(new ArrayList<>(List.of(attendee3, attendee4)));
+        schedule3.setTravelAttendeeList(new ArrayList<>(List.of(attendee5)));
 
         TravelRoute route1 = createTravelRoute(schedule1, travelPlace1, 1);
         TravelRoute route2 = createTravelRoute(schedule1, travelPlace1, 2);
@@ -131,24 +131,24 @@ public class ScheduleServiceTests extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.schedulePageable(1);
 
-        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2));
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2, schedule3));
         Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
 
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member3));
-        when(travelScheduleRepository.findTravelSchedulesByAttendee(pageable, member3.getMemberId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.findTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countSharedTravelSchedulesByUserId(anyString())).thenReturn(2);
 
         // when
-        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member3.getUserId());
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member1.getUserId());
 
         // then
         List<ScheduleInfoResponse> content = response.getContent();
-        assertEquals(response.getTotalElements(), 2);
-        assertEquals(response.getTotalSharedElements(), 1);
+        assertEquals(response.getTotalElements(), 3);
+        assertEquals(response.getTotalSharedElements(), 2);
         assertEquals(content.get(0).getScheduleName(), schedule1.getScheduleName());
         assertNotNull(content.get(0).getSinceUpdate());
         assertNotNull(content.get(0).getThumbnailUrl());
         assertEquals(content.get(0).getAuthor().getUserId(), member1.getUserId());
-        assertEquals(content.get(0).getRole(), AttendeeRole.GUEST);
+        assertEquals(content.get(0).getRole(), AttendeeRole.AUTHOR);
     }
 
     @Test
@@ -157,13 +157,11 @@ public class ScheduleServiceTests extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.schedulePageable(1);
 
-        schedule1.setTravelAttendeeList(new ArrayList<>(List.of(createTravelAttendee(member1, schedule1, AttendeeRole.AUTHOR, AttendeePermission.ALL))));
-
-        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1));
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule3));
         Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
 
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member1));
-        when(travelScheduleRepository.findTravelSchedulesByAttendee(pageable, member1.getMemberId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.findTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countSharedTravelSchedulesByUserId(anyString())).thenReturn(0);
 
         // when
         SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member1.getUserId());
@@ -172,29 +170,9 @@ public class ScheduleServiceTests extends ScheduleTest {
         List<ScheduleInfoResponse> content = response.getContent();
         assertEquals(response.getTotalElements(), 1);
         assertEquals(response.getTotalSharedElements(), 0);
-        assertEquals(content.get(0).getScheduleName(), schedule1.getScheduleName());
+        assertEquals(content.get(0).getScheduleName(), schedule3.getScheduleName());
         assertNotNull(content.get(0).getSinceUpdate());
-        assertNotNull(content.get(0).getThumbnailUrl());
         assertEquals(content.get(0).getAuthor().getUserId(), member1.getUserId());
-    }
-
-
-    @Test
-    @DisplayName("getSchedules(): 내 일정 목록 조회 시 사용자 데이터가 없는 경우")
-    void getSchedulesNoUserData(){
-        // given
-        int page = 1;
-        String userId = "member1";
-
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.empty());
-
-        // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getSchedules(page, userId));
-
-        // then
-        assertEquals(fail.getHttpStatus(), ErrorCode.USER_NOT_FOUND.getStatus());
-        assertEquals(fail.getMessage(), ErrorCode.USER_NOT_FOUND.getMessage());
-
     }
 
     @Test
@@ -205,11 +183,10 @@ public class ScheduleServiceTests extends ScheduleTest {
         String userId = "member1";
 
         Pageable pageable = PageUtil.schedulePageable(1);
-
         Page<TravelSchedule> emptySchedulePage = PageUtil.createPage(new ArrayList<>(), pageable, 0);
 
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(createMember(1L, userId)));
-        when(travelScheduleRepository.findTravelSchedulesByAttendee(pageable, 1L)).thenReturn(emptySchedulePage);
+        when(travelScheduleRepository.findTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(emptySchedulePage);
+        when(travelScheduleRepository.countSharedTravelSchedulesByUserId(anyString())).thenReturn(2);
 
         // when
         SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(page, userId);
@@ -225,17 +202,16 @@ public class ScheduleServiceTests extends ScheduleTest {
     void getSchedulesNoImageThumbnail(){
         // given
         Pageable pageable = PageUtil.schedulePageable(1);
-
         travelPlace1.getTravelImageList().get(0).setThumbnail(false);
 
         List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2));
         Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
 
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member3));
-        when(travelScheduleRepository.findTravelSchedulesByAttendee(pageable, member3.getMemberId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.findTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countSharedTravelSchedulesByUserId(anyString())).thenReturn(1);
 
         // when
-        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member3.getUserId());
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member1.getUserId());
 
         // then
         List<ScheduleInfoResponse> content = response.getContent();
@@ -254,18 +230,18 @@ public class ScheduleServiceTests extends ScheduleTest {
         Pageable pageable = PageUtil.schedulePageable(1);
         travelPlace1.setTravelImageList(new ArrayList<>());
 
-        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2));
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1));
         Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
 
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member3));
-        when(travelScheduleRepository.findTravelSchedulesByAttendee(pageable, member3.getMemberId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.findTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countSharedTravelSchedulesByUserId(anyString())).thenReturn(1);
 
         // when
-        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member3.getUserId());
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSchedules(1, member1.getUserId());
 
         // then
         List<ScheduleInfoResponse> content = response.getContent();
-        assertEquals(response.getTotalElements(), 2);
+        assertEquals(response.getTotalElements(), 1);
         assertEquals(content.get(0).getScheduleName(), "테스트1");
         assertNotNull(content.get(0).getSinceUpdate());
         assertNull(content.get(0).getThumbnailUrl());
@@ -273,45 +249,171 @@ public class ScheduleServiceTests extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("convertToScheduleOverviewResponse(): TravelSchedule 를 TravelOverviewResponse 로 변경")
-    void convertToScheduleInfoResponse(){
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회")
+    void getSharedSchedules(){
         // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
+
+        when(travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countTravelSchedulesByUserId(anyString())).thenReturn(3);
+
         // when
-        ScheduleInfoResponse response = scheduleService.convertToScheduleInfoResponse(member1, schedule1);
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(1, member1.getUserId());
 
         // then
-        assertEquals(response.getScheduleName(), schedule1.getScheduleName());
-        assertNotNull(response.getSinceUpdate());
-        assertNotNull(response.getThumbnailUrl());
-        assertEquals(response.getAuthor().getUserId(), member1.getUserId());
+        List<ScheduleInfoResponse> content = response.getContent();
+        assertEquals(response.getTotalElements(), 3);
+        assertEquals(response.getTotalSharedElements(), 2);
+        assertEquals(content.get(0).getScheduleName(), schedule1.getScheduleName());
+        assertNotNull(content.get(0).getSinceUpdate());
+        assertNotNull(content.get(0).getThumbnailUrl());
+        assertEquals(content.get(0).getAuthor().getUserId(), member1.getUserId());
+        assertEquals(content.get(0).getRole(), AttendeeRole.AUTHOR);
     }
 
     @Test
-    @DisplayName("convertToScheduleOverviewResponse(): TravelSchedule 를 TravelOverviewResponse 로 변경 시 썸네일 없는 경우")
-    void convertToScheduleInfoResponseWithoutThumbnail(){
+    @DisplayName("getSharedSchedules(): 공유된 목록 조회 시 공유된 일정이 없는 경우")
+    void getSharedSchedulesNotShared(){
         // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(new ArrayList<>(), pageable, 0);
+
+        when(travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countTravelSchedulesByUserId(anyString())).thenReturn(3);
+
+        // when
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(1, member1.getUserId());
+
+        // then
+        List<ScheduleInfoResponse> content = response.getContent();
+        assertEquals(response.getTotalElements(), 3);
+        assertEquals(response.getTotalSharedElements(), 0);
+        assertTrue(content.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회 시 일정 데이터 없는 경우")
+    void getSharedSchedulesNoScheduleData(){
+        // given
+        int page = 1;
+        String userId = "member1";
+
+        Pageable pageable = PageUtil.schedulePageable(1);
+        Page<TravelSchedule> emptySchedulePage = PageUtil.createPage(new ArrayList<>(), pageable, 0);
+
+        when(travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(emptySchedulePage);
+        when(travelScheduleRepository.countTravelSchedulesByUserId(anyString())).thenReturn(2);
+
+        // when
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(page, userId);
+
+        // then
+        assertEquals(response.getTotalElements(), 2);
+        assertTrue(response.getContent().isEmpty());
+    }
+
+    @Test
+    @DisplayName("getSharedSchedules(): 공유된 일정 목록 조회 시 이미지 썸네일 데이터 없는 경우")
+    void getSharedSchedulesNoImageThumbnail(){
+        // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+        travelPlace1.getTravelImageList().get(0).setThumbnail(false);
+
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1, schedule2));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
+
+        when(travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countTravelSchedulesByUserId(anyString())).thenReturn(3);
+
+        // when
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(1, member1.getUserId());
+
+        // then
+        List<ScheduleInfoResponse> content = response.getContent();
+        assertEquals(response.getTotalElements(), 3);
+        assertEquals(content.get(0).getScheduleName(), "테스트1");
+        assertNotNull(content.get(0).getSinceUpdate());
+        assertNull(content.get(0).getThumbnailUrl());
+
+    }
+
+
+    @Test
+    @DisplayName("getSharedSchedules(): 내 일정 목록 조회 시 이미지 데이터 없는 경우")
+    void getSharedSchedulesNoImageData(){
+        // given
+        Pageable pageable = PageUtil.schedulePageable(1);
+        travelPlace1.setTravelImageList(new ArrayList<>());
+
+        List<TravelSchedule> schedules = new ArrayList<>(List.of(schedule1));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(schedules, pageable, schedules.size());
+
+        when(travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, member1.getUserId())).thenReturn(schedulePage);
+        when(travelScheduleRepository.countTravelSchedulesByUserId(anyString())).thenReturn(1);
+
+        // when
+        SchedulePageResponse<ScheduleInfoResponse> response = scheduleService.getSharedSchedules(1, member1.getUserId());
+
+        // then
+        List<ScheduleInfoResponse> content = response.getContent();
+        assertEquals(response.getTotalElements(), 1);
+        assertEquals(content.get(0).getScheduleName(), "테스트1");
+        assertNotNull(content.get(0).getSinceUpdate());
+        assertNull(content.get(0).getThumbnailUrl());
+
+    }
+
+    @Test
+    @DisplayName("createScheduleInfoResponse(): TravelSchedule 를 ScheduleInfoResponse 로 변경")
+    void createScheduleInfoResponse(){
+        // given
+        List<TravelSchedule> travelScheduleList = new ArrayList<>(List.of(schedule1));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(travelScheduleList, PageUtil.schedulePageable(1), travelScheduleList.size());
+        // when
+        List<ScheduleInfoResponse> response = scheduleService.createScheduleInfoResponse(schedulePage, member1.getUserId());
+
+        // then
+        assertEquals(response.size(), 1);
+        assertEquals(response.get(0).getScheduleName(), schedule1.getScheduleName());
+        assertNotNull(response.get(0).getSinceUpdate());
+        assertNotNull(response.get(0).getThumbnailUrl());
+        assertEquals(response.get(0).getAuthor().getUserId(), member1.getUserId());
+    }
+
+    @Test
+    @DisplayName("createScheduleInfoResponse(): TravelSchedule 를 ScheduleInfoResponse 로 변경 시 썸네일 없는 경우")
+    void createScheduleInfoResponseWithoutThumbnail(){
+        // given
+        List<TravelSchedule> travelScheduleList = new ArrayList<>(List.of(schedule1));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(travelScheduleList, PageUtil.schedulePageable(1), travelScheduleList.size());
         travelPlace1.getTravelImageList().get(0).setThumbnail(false);
 
         // when
-        ScheduleInfoResponse response = scheduleService.convertToScheduleInfoResponse(member1, schedule1);
+        List<ScheduleInfoResponse> response = scheduleService.createScheduleInfoResponse(schedulePage, member1.getUserId());
 
         // then
-        assertEquals(response.getScheduleName(), schedule1.getScheduleName());
-        assertNotNull(response.getSinceUpdate());
-        assertNull(response.getThumbnailUrl());
-        assertEquals(response.getAuthor().getUserId(), member1.getUserId());
+        assertEquals(response.get(0).getScheduleName(), schedule1.getScheduleName());
+        assertNotNull(response.get(0).getSinceUpdate());
+        assertNull(response.get(0).getThumbnailUrl());
+        assertEquals(response.get(0).getAuthor().getUserId(), member1.getUserId());
     }
 
     @Test
-    @DisplayName("convertToScheduleOverviewResponse(): TravelSchedule 를 TravelOverviewResponse 로 변경 시 작성자가 없어 예외 발생")
-    void convertToScheduleInfoResponse_notFoundException(){
+    @DisplayName("createScheduleInfoResponse(): TravelSchedule 를 ScheduleInfoResponse 로 변경 시 작성자가 없어 예외 발생")
+    void createScheduleInfoResponse_notFoundException(){
         // given
+        List<TravelSchedule> travelScheduleList = new ArrayList<>(List.of(schedule1));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(travelScheduleList, PageUtil.schedulePageable(1), travelScheduleList.size());
         for(TravelAttendee attendee : schedule1.getTravelAttendeeList()){
             attendee.setRole(AttendeeRole.GUEST);
         }
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.convertToScheduleInfoResponse(member1, schedule1));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.createScheduleInfoResponse(schedulePage, member1.getUserId()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.AUTHOR_NOT_FOUND.getStatus());
@@ -320,11 +422,14 @@ public class ScheduleServiceTests extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("convertToScheduleOverviewResponse(): TravelSchedule 를 TravelOverviewResponse 로 변경 시 접근 권한이 없어 예외 발생")
-    void convertToScheduleInfoResponse_forbiddenScheduleException(){
+    @DisplayName("convertToScheduleOverviewResponse(): TravelSchedule 를 ScheduleInfoResponse 로 변경 시 접근 권한이 없어 예외 발생")
+    void createScheduleInfoResponse_forbiddenScheduleException(){
         // given
+        List<TravelSchedule> travelScheduleList = new ArrayList<>(List.of(schedule3));
+        Page<TravelSchedule> schedulePage = PageUtil.createPage(travelScheduleList, PageUtil.schedulePageable(1), travelScheduleList.size());
+
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.convertToScheduleInfoResponse(member1, schedule2));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.createScheduleInfoResponse(schedulePage, member2.getUserId()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
@@ -334,10 +439,10 @@ public class ScheduleServiceTests extends ScheduleTest {
 
     @Test
     @DisplayName("getAuthorDTO() : 작성자 조회해서 dto 생성")
-    void getAuthorDTO(){
+    void createAuthorDTO(){
         // given
         // when
-        AuthorDTO response = scheduleService.getAuthorDTO(schedule1);
+        AuthorDTO response = scheduleService.createAuthorDTO(schedule1);
 
         // then
         assertEquals(response.getUserId(), member1.getUserId());
@@ -347,48 +452,19 @@ public class ScheduleServiceTests extends ScheduleTest {
 
     @Test
     @DisplayName("getAuthorDTO() : 작성자 조회해서 dto 생성 시 작성자가 없어 예외 발생")
-    void getAuthorDTO_notFoundException(){
+    void createAuthorDTO_notFoundException(){
         // given
         for(TravelAttendee attendee : schedule1.getTravelAttendeeList()){
             attendee.setRole(AttendeeRole.GUEST);
         }
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getAuthorDTO(schedule1));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.createAuthorDTO(schedule1));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.AUTHOR_NOT_FOUND.getStatus());
         assertEquals(fail.getMessage(), ErrorCode.AUTHOR_NOT_FOUND.getMessage());
 
-    }
-
-
-    @Test
-    @DisplayName("getAuthorMember() : 일정 작성자 조회")
-    void getAuthorMember(){
-        // given
-        // when
-        Member response = scheduleService.getAuthorMember(schedule1.getTravelAttendeeList());
-
-        // then
-        assertEquals(response.getMemberId(), member1.getMemberId());
-        assertEquals(response.getUserId(), member1.getUserId());
-    }
-
-    @Test
-    @DisplayName("getAuthorMember() : 일정 작성자 조회 시 작성자가 없어 예외 발생")
-    void getAuthorMember_notFoundException(){
-        // given
-        for(TravelAttendee attendee : schedule1.getTravelAttendeeList()){
-            attendee.setRole(AttendeeRole.GUEST);
-        }
-
-        // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getAuthorMember(schedule1.getTravelAttendeeList()));
-
-        // then
-        assertEquals(fail.getHttpStatus(), ErrorCode.AUTHOR_NOT_FOUND.getStatus());
-        assertEquals(fail.getMessage(), ErrorCode.AUTHOR_NOT_FOUND.getMessage());
     }
 
 
@@ -414,7 +490,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         String response = scheduleService.getThumbnailUrl(schedule1);
 
         // then
-        System.out.println(response);
         assertNull(response);
     }
 
@@ -544,7 +619,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         UpdateScheduleRequest updateScheduleRequest = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
         when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule1));
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member1));
         when(travelPlaceRepository.findByPlaceId(travelPlace1.getPlaceId())).thenReturn(Optional.of(travelPlace1));
         when(travelPlaceRepository.findByPlaceId(travelPlace2.getPlaceId())).thenReturn(Optional.of(travelPlace2));
 
@@ -562,7 +636,7 @@ public class ScheduleServiceTests extends ScheduleTest {
     @DisplayName("updateSchedule(): 일정 수정 중 여행 루트 삭제에서 기존에 저장된 여행 루트가 없을 경우")
     void updateScheduleNoSavedTravelRouteList(){
         // given
-        String userId = member3.getUserId();
+        String userId = member1.getUserId();
         Long scheduleId = schedule2.getScheduleId();
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
@@ -570,7 +644,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         UpdateScheduleRequest updateScheduleRequest = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
         when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule2));
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member3));
         when(travelPlaceRepository.findByPlaceId(travelPlace1.getPlaceId())).thenReturn(Optional.of(travelPlace1));
         when(travelPlaceRepository.findByPlaceId(travelPlace2.getPlaceId())).thenReturn(Optional.of(travelPlace2));
 
@@ -646,15 +719,14 @@ public class ScheduleServiceTests extends ScheduleTest {
     @DisplayName("updateSchedule(): 일정 수정 시 요청 사용자에게 접근 권한이 없어 예외 발생")
     void updateScheduleForbiddenAccess_forbiddenScheduleException(){
         // given
-        String userId = member1.getUserId();
-        Long scheduleId = schedule2.getScheduleId();
+        String userId = member2.getUserId();
+        Long scheduleId = schedule3.getScheduleId();
 
         RouteRequest routeRequest1 = createRouteRequest(1, travelPlace1.getPlaceId());
         RouteRequest routeRequest2 = createRouteRequest(2, travelPlace2.getPlaceId());
         UpdateScheduleRequest updateScheduleRequest = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
-        when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule2));
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member1));
+        when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule3));
 
         // when
         ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.updateSchedule(userId, scheduleId, updateScheduleRequest));
@@ -677,7 +749,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         UpdateScheduleRequest updateScheduleRequest = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
         when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule1));
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member2));
 
         // when
         ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.updateSchedule(userId, scheduleId, updateScheduleRequest));
@@ -700,7 +771,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         UpdateScheduleRequest updateScheduleRequest = createUpdateScheduleRequest(new ArrayList<>(List.of(routeRequest1, routeRequest2)));
 
         when(travelScheduleRepository.findByScheduleId(scheduleId)).thenReturn(Optional.of(schedule1));
-        when(memberRepository.findByUserId(userId)).thenReturn(Optional.of(member1));
         when(travelPlaceRepository.findByPlaceId(anyLong())).thenReturn(Optional.empty());
 
         // when
@@ -716,7 +786,7 @@ public class ScheduleServiceTests extends ScheduleTest {
     void getAttendeeInfo_containsAttendees(){
         // given
         // when
-        TravelAttendee response = scheduleService.getAttendeeInfo(member1, schedule1);
+        TravelAttendee response = scheduleService.getAttendeeInfo(schedule1, member1.getUserId());
 
         // then
         assertEquals(response.getMember().getUserId(), member1.getUserId());
@@ -728,7 +798,7 @@ public class ScheduleServiceTests extends ScheduleTest {
     void getAttendeeInfo_notContainsAttendees(){
         // given
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.getAttendeeInfo(member1, schedule2));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.getAttendeeInfo(schedule3, member2.getUserId()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
@@ -742,8 +812,7 @@ public class ScheduleServiceTests extends ScheduleTest {
         // given
         AttendeePermission permission = AttendeePermission.ALL;
 
-        // when
-        // then
+        // when, then
         assertDoesNotThrow(() -> scheduleService.checkUserPermission(permission));
     }
 
@@ -790,8 +859,7 @@ public class ScheduleServiceTests extends ScheduleTest {
     @DisplayName("deleteSchedule(): 일정 삭제")
     void deleteSchedule(){
         // given
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member1));
+        when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee1));
 
         // when
         assertDoesNotThrow(() -> scheduleService.deleteSchedule(schedule1.getScheduleId(), member1.getUserId()));
@@ -801,8 +869,7 @@ public class ScheduleServiceTests extends ScheduleTest {
     @DisplayName("deleteSchedule(): 일정 삭제 시 작성자가 아닌 사용자가 삭제 요청으로 인해 예외 발생")
     void deleteScheduleNotAuthor_forbiddenScheduleException(){
         // given
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
-        when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member2));
+        when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee2));
 
         // when
         ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.deleteSchedule(schedule1.getScheduleId(), member2.getUserId()));
@@ -811,214 +878,6 @@ public class ScheduleServiceTests extends ScheduleTest {
         assertEquals(fail.getMessage(), ErrorCode.FORBIDDEN_DELETE_SCHEDULE.getMessage());
     }
 
-
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 성공")
-    void getTravelPlaces(){
-        // given
-        List<TravelPlace> placeList = new ArrayList<>(List.of(travelPlace1, travelPlace2));
-
-        TravelSchedule schedule = createTravelSchedule(1L, "테스트");
-
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule));
-        when(travelPlaceRepository.findAllByAreaData(any(), anyString(), anyString(), anyString()))
-                .thenReturn(PageUtil.createPage(placeList, pageable, 1));
-
-        // when
-        Page<PlaceResponse> response = scheduleService.getTravelPlaces(schedule.getScheduleId(), 1);
-
-        // then
-        assertEquals(response.getTotalElements(), placeList.size());
-        assertEquals(response.getContent().get(0).getPlaceName(), placeList.get(0).getPlaceName());
-        assertNotNull(response.getContent().get(0).getThumbnailUrl());
-    }
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 시 여행지 데이터 없는 경우")
-    void getTravelPlacesWithoutData(){
-        // given
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
-        when(travelPlaceRepository.findAllByAreaData(any(), anyString(), anyString(), anyString()))
-                .thenReturn(PageUtil.createPage(new ArrayList<>(), pageable, 0));
-
-        // when
-        Page<PlaceResponse> response = scheduleService.getTravelPlaces(schedule1.getScheduleId(), 1);
-
-        // then
-        assertEquals(response.getTotalElements(), 0);
-        assertTrue(response.getContent().isEmpty());
-    }
-
-    @Test
-    @DisplayName("getTravelPlaces(): 여행지 조회 시 일정을 찾을 수 없어 예외 발생")
-    void getTravelPlaces_dataNotFoundException(){
-        // given
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.empty());
-
-        // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getTravelPlaces(0L, 1));
-
-        // then
-        assertEquals(fail.getHttpStatus(), ErrorCode.SCHEDULE_NOT_FOUND.getStatus());
-        assertEquals(fail.getMessage(), ErrorCode.SCHEDULE_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 성공")
-    void searchTravelPlaces(){
-        // given
-        String keyword = "중구";
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        List<TravelPlace> travelPlaceList = new ArrayList<>(List.of(travelPlace1, travelPlace2));
-        Page<TravelPlace> travelPlacePage = PageUtil.createPage(travelPlaceList, pageable, travelPlaceList.size());
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(createTravelSchedule(1L, "테스트")));
-        when(travelPlaceRepository.searchTravelPlaces(pageable, keyword)).thenReturn(travelPlacePage);
-
-        // when
-        Page<PlaceResponse> response = scheduleService.searchTravelPlaces(1L, 1, keyword);
-
-
-        // then
-        List<PlaceResponse> content = response.getContent();
-        assertEquals(content.get(0).getPlaceName(), travelPlace1.getPlaceName());
-        assertEquals(content.get(0).getAddress(), travelPlace1.getAddress());
-        assertNotNull(content.get(0).getThumbnailUrl());
-    }
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 시 검색 결과 존재하지 않는 경우")
-    void searchTravelPlacesWithoutData(){
-        // given
-        String keyword = "ㅁㄴㅇㄹ";
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        Page<TravelPlace> travelPlacePage = PageUtil.createPage(new ArrayList<>(), pageable, 0);
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(createTravelSchedule(1L, "테스트")));
-        when(travelPlaceRepository.searchTravelPlaces(pageable, keyword)).thenReturn(travelPlacePage);
-
-        // when
-        Page<PlaceResponse> response = scheduleService.searchTravelPlaces(1L, 1, keyword);
-
-
-        // then
-        assertEquals(response.getTotalElements(), 0);
-    }
-
-    @Test
-    @DisplayName("searchTravelPlaces(): 여행지 검색 시 일정을 찾을 수 없어 예외 발생")
-    void searchTravelPlaces_dataNotFoundException(){
-        // given
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.empty());
-
-        // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.searchTravelPlaces(0L, 1, "강남"));
-
-        // then
-        assertEquals(fail.getHttpStatus(), ErrorCode.SCHEDULE_NOT_FOUND.getStatus());
-        assertEquals(fail.getMessage(), ErrorCode.SCHEDULE_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 성공")
-    void getTravelRoutes(){
-        // given
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
-        when(travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, schedule1.getScheduleId()))
-                .thenReturn(PageUtil.createPage(schedule1.getTravelRouteList(), pageable, schedule1.getTravelRouteList().size()));
-
-
-        // when
-        Page<RouteResponse> response = scheduleService.getTravelRoutes(schedule1.getScheduleId(), 1);
-
-        // then
-        List<RouteResponse> content = response.getContent();
-        assertEquals(response.getTotalElements(), schedule1.getTravelRouteList().size());
-        assertEquals(content.get(0).getAddress(), travelPlace1.getAddress());
-        assertEquals(content.get(0).getRouteOrder(), schedule1.getTravelRouteList().get(0).getRouteOrder());
-        assertEquals(content.get(1).getRouteOrder(), schedule1.getTravelRouteList().get(1).getRouteOrder());
-        assertEquals(content.get(2).getRouteOrder(), schedule1.getTravelRouteList().get(2).getRouteOrder());
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 저장된 여행 루트 데이터 없는 경우")
-    void getTravelRoutesWithoutData(){
-        // given
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
-        when(travelRouteRepository.findAllByTravelSchedule_ScheduleId(pageable, schedule1.getScheduleId()))
-                .thenReturn(PageUtil.createPage(new ArrayList<>(), pageable, 0));
-
-
-        // when
-        Page<RouteResponse> response = scheduleService.getTravelRoutes(schedule1.getScheduleId(), 1);
-
-        // then
-        assertEquals(response.getTotalElements(), 0);
-        assertTrue(response.getContent().isEmpty());
-    }
-
-    @Test
-    @DisplayName("getTravelRoutes(): 여행 루트 조회 시 일정을 찾을 수 없어 예외 발생")
-    void getTravelRoutes_dataNotFoundException(){
-        // given
-        when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.empty());
-
-        // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getTravelRoutes(0L, 1));
-
-        // then
-        assertEquals(fail.getHttpStatus(), ErrorCode.SCHEDULE_NOT_FOUND.getStatus());
-        assertEquals(fail.getMessage(), ErrorCode.SCHEDULE_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("getSimpleTravelPlacesByJunggu(): 중구 기준 여행지 데이터 조회")
-    void getSimpleTravelPlacesByJunggu(){
-        // given
-        List<TravelPlace> placeList = new ArrayList<>(List.of(travelPlace1, travelPlace2));
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelPlaceRepository.findAllByAreaData(pageable, "대한민국", "서울", "중구"))
-                .thenReturn(PageUtil.createPage(placeList, pageable, placeList.size()));
-
-
-        // when
-        Page<PlaceResponse> response = scheduleService.getSimpleTravelPlacesByJunggu(1);
-
-        // then
-        List<PlaceResponse> content = response.getContent();
-        assertEquals(response.getTotalElements(), placeList.size());
-        assertEquals(content.get(0).getAddress(), travelPlace1.getAddress());
-    }
-
-    @Test
-    @DisplayName("getSimpleTravelPlacesByJunggu(): 중구 기준 여행지 데이터 조회 시 데이터 없는 경우")
-    void getSimpleTravelPlacesByJungguWithoutData(){
-        // given
-        Pageable pageable = PageUtil.defaultPageable(1);
-
-        when(travelPlaceRepository.findAllByAreaData(pageable, "대한민국", "서울", "중구"))
-                .thenReturn(PageUtil.createPage(new ArrayList<>(), pageable, 0));
-
-
-        // when
-        Page<PlaceResponse> response = scheduleService.getSimpleTravelPlacesByJunggu(1);
-
-        // then
-        assertEquals(response.getTotalElements(), 0);
-        assertTrue(response.getContent().isEmpty());
-    }
 
     @Test
     @DisplayName("getSavedMember(): 저장된 사용자 정보 조회")

--- a/src/test/java/com/triptune/domain/schedule/service/ScheduleTravelServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ScheduleTravelServiceTest.java
@@ -1,0 +1,155 @@
+package com.triptune.domain.schedule.service;
+
+import com.triptune.domain.common.entity.ApiCategory;
+import com.triptune.domain.common.entity.City;
+import com.triptune.domain.common.entity.Country;
+import com.triptune.domain.common.entity.District;
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.entity.ProfileImage;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.TravelAttendee;
+import com.triptune.domain.schedule.entity.TravelRoute;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import com.triptune.domain.schedule.enumclass.AttendeePermission;
+import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
+import com.triptune.domain.schedule.repository.TravelRouteRepository;
+import com.triptune.domain.schedule.repository.TravelScheduleRepository;
+import com.triptune.domain.travel.dto.response.PlaceResponse;
+import com.triptune.domain.travel.entity.TravelImage;
+import com.triptune.domain.travel.entity.TravelPlace;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
+import com.triptune.global.enumclass.ErrorCode;
+import com.triptune.global.exception.DataNotFoundException;
+import com.triptune.global.util.PageUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ScheduleTravelServiceTest extends ScheduleTest {
+    @InjectMocks
+    private ScheduleTravelService scheduleTravelService;
+
+    @Mock
+    private TravelPlaceRepository travelPlaceRepository;
+
+
+    private TravelPlace travelPlace1;
+    private TravelPlace travelPlace2;
+
+    @BeforeEach
+    void setUp(){
+        Country country = createCountry();
+        City city = createCity(country);
+        District district = createDistrict(city, "중구");
+        ApiCategory apiCategory = createApiCategory();
+        travelPlace1 = createTravelPlace(1L, country, city, district, apiCategory);
+        TravelImage travelImage1 = createTravelImage(travelPlace1, "test1", true);
+        TravelImage travelImage2 = createTravelImage(travelPlace1, "test2", false);
+        travelPlace1.setTravelImageList(new ArrayList<>(List.of(travelImage1, travelImage2)));
+
+        travelPlace2 = createTravelPlace(2L, country, city, district, apiCategory);
+        TravelImage travelImage3 = createTravelImage(travelPlace2, "test1", true);
+        TravelImage travelImage4 = createTravelImage(travelPlace2, "test2", false);
+        travelPlace2.setTravelImageList(new ArrayList<>(List.of(travelImage3, travelImage4)));
+    }
+
+
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 성공")
+    void getTravelPlaces(){
+        // given
+        List<TravelPlace> placeList = new ArrayList<>(List.of(travelPlace1, travelPlace2));
+        Pageable pageable = PageUtil.defaultPageable(1);
+
+        when(travelPlaceRepository.findAllByAreaData(any(), anyString(), anyString(), anyString()))
+                .thenReturn(PageUtil.createPage(placeList, pageable, 1));
+
+        // when
+        Page<PlaceResponse> response = scheduleTravelService.getTravelPlaces(1);
+
+        // then
+        assertEquals(response.getTotalElements(), placeList.size());
+        assertEquals(response.getContent().get(0).getPlaceName(), placeList.get(0).getPlaceName());
+        assertNotNull(response.getContent().get(0).getThumbnailUrl());
+    }
+
+    @Test
+    @DisplayName("getTravelPlaces(): 여행지 조회 시 여행지 데이터 없는 경우")
+    void getTravelPlacesWithoutData(){
+        // given
+        Pageable pageable = PageUtil.defaultPageable(1);
+
+        when(travelPlaceRepository.findAllByAreaData(any(), anyString(), anyString(), anyString()))
+                .thenReturn(PageUtil.createPage(new ArrayList<>(), pageable, 0));
+
+        // when
+        Page<PlaceResponse> response = scheduleTravelService.getTravelPlaces(1);
+
+        // then
+        assertEquals(response.getTotalElements(), 0);
+        assertTrue(response.getContent().isEmpty());
+    }
+
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 성공")
+    void searchTravelPlaces(){
+        // given
+        String keyword = "중구";
+        Pageable pageable = PageUtil.defaultPageable(1);
+
+        List<TravelPlace> travelPlaceList = new ArrayList<>(List.of(travelPlace1, travelPlace2));
+        Page<TravelPlace> travelPlacePage = PageUtil.createPage(travelPlaceList, pageable, travelPlaceList.size());
+
+        when(travelPlaceRepository.searchTravelPlaces(pageable, keyword)).thenReturn(travelPlacePage);
+
+        // when
+        Page<PlaceResponse> response = scheduleTravelService.searchTravelPlaces(1, keyword);
+
+
+        // then
+        List<PlaceResponse> content = response.getContent();
+        assertEquals(content.get(0).getPlaceName(), travelPlace1.getPlaceName());
+        assertEquals(content.get(0).getAddress(), travelPlace1.getAddress());
+        assertNotNull(content.get(0).getThumbnailUrl());
+    }
+
+    @Test
+    @DisplayName("searchTravelPlaces(): 여행지 검색 시 검색 결과 존재하지 않는 경우")
+    void searchTravelPlacesWithoutData(){
+        // given
+        String keyword = "ㅁㄴㅇㄹ";
+        Pageable pageable = PageUtil.defaultPageable(1);
+        Page<TravelPlace> travelPlacePage = PageUtil.createPage(new ArrayList<>(), pageable, 0);
+
+        when(travelPlaceRepository.searchTravelPlaces(pageable, keyword)).thenReturn(travelPlacePage);
+
+        // when
+        Page<PlaceResponse> response = scheduleTravelService.searchTravelPlaces(1, keyword);
+
+
+        // then
+        assertEquals(response.getTotalElements(), 0);
+    }
+
+}

--- a/src/test/java/com/triptune/domain/travel/controller/TravelApiControllerTests.java
+++ b/src/test/java/com/triptune/domain/travel/controller/TravelApiControllerTests.java
@@ -6,7 +6,7 @@ import com.triptune.domain.travel.TravelTest;
 import com.triptune.domain.travel.entity.TravelImage;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TravelApiControllerTests extends TravelTest {
 
     private final WebApplicationContext wac;
-    private final TravelPlacePlaceRepository travelPlaceRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
     private final CountryRepository countryRepository;
     private final CityRepository cityRepository;
     private final DistrictRepository districtRepository;
@@ -46,7 +46,7 @@ public class TravelApiControllerTests extends TravelTest {
     private final ApiContentTypeRepository apiContentTypeRepository;
 
     @Autowired
-    public TravelApiControllerTests(WebApplicationContext wac, TravelPlacePlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
+    public TravelApiControllerTests(WebApplicationContext wac, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
         this.wac = wac;
         this.travelPlaceRepository = travelPlaceRepository;
         this.countryRepository = countryRepository;

--- a/src/test/java/com/triptune/domain/travel/controller/TravelControllerTest.java
+++ b/src/test/java/com/triptune/domain/travel/controller/TravelControllerTest.java
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @TestPropertySource(locations = "classpath:application-test.yml")
-public class TravelApiControllerTests extends TravelTest {
+public class TravelControllerTest extends TravelTest {
 
     private final WebApplicationContext wac;
     private final TravelPlaceRepository travelPlaceRepository;
@@ -46,7 +46,7 @@ public class TravelApiControllerTests extends TravelTest {
     private final ApiContentTypeRepository apiContentTypeRepository;
 
     @Autowired
-    public TravelApiControllerTests(WebApplicationContext wac, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
+    public TravelControllerTest(WebApplicationContext wac, TravelPlaceRepository travelPlaceRepository, CountryRepository countryRepository, CityRepository cityRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
         this.wac = wac;
         this.travelPlaceRepository = travelPlaceRepository;
         this.countryRepository = countryRepository;

--- a/src/test/java/com/triptune/domain/travel/respository/TravelImageRepositoryTest.java
+++ b/src/test/java/com/triptune/domain/travel/respository/TravelImageRepositoryTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
-public class TravelImageRepositoryTests {
+public class TravelImageRepositoryTest {
 
     @Autowired
     private TravelImageRepository travelImageRepository;

--- a/src/test/java/com/triptune/domain/travel/respository/TravelPlaceRepositoryTest.java
+++ b/src/test/java/com/triptune/domain/travel/respository/TravelPlaceRepositoryTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Import({QueryDSLConfig.class})
 @ActiveProfiles("test")
 @TestPropertySource(locations = "classpath:application-test.yml")
-public class TravelPlaceRepositoryTests extends TravelTest {
+public class TravelPlaceRepositoryTest extends TravelTest {
     private final TravelPlaceRepository travelPlaceRepository;
     private final CityRepository cityRepository;
     private final CountryRepository countryRepository;
@@ -44,7 +44,7 @@ public class TravelPlaceRepositoryTests extends TravelTest {
     private TravelPlace travelPlace1;
 
     @Autowired
-    public TravelPlaceRepositoryTests(TravelPlaceRepository travelPlaceRepository, CityRepository cityRepository, CountryRepository countryRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
+    public TravelPlaceRepositoryTest(TravelPlaceRepository travelPlaceRepository, CityRepository cityRepository, CountryRepository countryRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
         this.travelPlaceRepository = travelPlaceRepository;
         this.cityRepository = cityRepository;
         this.countryRepository = countryRepository;

--- a/src/test/java/com/triptune/domain/travel/respository/TravelPlaceRepositoryTests.java
+++ b/src/test/java/com/triptune/domain/travel/respository/TravelPlaceRepositoryTests.java
@@ -9,7 +9,7 @@ import com.triptune.domain.travel.dto.request.PlaceSearchRequest;
 import com.triptune.domain.travel.entity.TravelImage;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.config.QueryDSLConfig;
 import com.triptune.global.util.PageUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 @TestPropertySource(locations = "classpath:application-test.yml")
 public class TravelPlaceRepositoryTests extends TravelTest {
-    private final TravelPlacePlaceRepository travelPlaceRepository;
+    private final TravelPlaceRepository travelPlaceRepository;
     private final CityRepository cityRepository;
     private final CountryRepository countryRepository;
     private final DistrictRepository districtRepository;
@@ -44,7 +44,7 @@ public class TravelPlaceRepositoryTests extends TravelTest {
     private TravelPlace travelPlace1;
 
     @Autowired
-    public TravelPlaceRepositoryTests(TravelPlacePlaceRepository travelPlaceRepository, CityRepository cityRepository, CountryRepository countryRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
+    public TravelPlaceRepositoryTests(TravelPlaceRepository travelPlaceRepository, CityRepository cityRepository, CountryRepository countryRepository, DistrictRepository districtRepository, ApiCategoryRepository apiCategoryRepository, TravelImageRepository travelImageRepository, ApiContentTypeRepository apiContentTypeRepository) {
         this.travelPlaceRepository = travelPlaceRepository;
         this.cityRepository = cityRepository;
         this.countryRepository = countryRepository;

--- a/src/test/java/com/triptune/domain/travel/service/TravelServiceTest.java
+++ b/src/test/java/com/triptune/domain/travel/service/TravelServiceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class TravelServiceTests extends TravelTest {
+public class TravelServiceTest extends TravelTest {
 
     @InjectMocks
     private TravelService travelService;

--- a/src/test/java/com/triptune/domain/travel/service/TravelServiceTests.java
+++ b/src/test/java/com/triptune/domain/travel/service/TravelServiceTests.java
@@ -10,7 +10,7 @@ import com.triptune.domain.travel.dto.response.PlaceDistanceResponse;
 import com.triptune.domain.travel.entity.TravelImage;
 import com.triptune.domain.travel.entity.TravelPlace;
 import com.triptune.domain.travel.repository.TravelImageRepository;
-import com.triptune.domain.travel.repository.TravelPlacePlaceRepository;
+import com.triptune.domain.travel.repository.TravelPlaceRepository;
 import com.triptune.global.enumclass.ErrorCode;
 import com.triptune.global.exception.DataNotFoundException;
 import com.triptune.global.util.PageUtil;
@@ -41,7 +41,7 @@ public class TravelServiceTests extends TravelTest {
     private TravelService travelService;
 
     @Mock
-    private TravelPlacePlaceRepository travelPlaceRepository;
+    private TravelPlaceRepository travelPlaceRepository;
 
     @Mock
     private TravelImageRepository travelImageRepository;

--- a/src/test/java/com/triptune/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/triptune/global/config/SecurityConfigTest.java
@@ -1,7 +1,6 @@
 package com.triptune.global.config;
 
 import com.triptune.global.util.HttpRequestEndpointChecker;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -18,12 +16,11 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class SecurityConfigTests {
+public class SecurityConfigTest {
 
     @Autowired
     private WebApplicationContext wac;


### PR DESCRIPTION
## 신규 구현
1. 일정 나가기
2. 일정 목록 중 공유된 일정만 조회
3. 일정 검색
3.1. 전체 일정 검색
3.2. 공유된 일정 중 검색

<br>

## 리팩토링
1. 일정에 접근 시 참가자인지 체크하는 부분 aop로 구현 
: 반복적으로 사용되는 코드이기 때문에 수정

2. 기존 schedule의 controller와 service 코드 분리
: schedule 코드가 길어져 비슷한 기능끼리 controller, service 분리

3. of, from 함수 구현 및 이름 변경

