### PR TITLE
[update] 채팅 예외 처리 변경 및 채팅 삭제 추가

### DIFF
--- a/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/AttendeeController.java
@@ -6,7 +6,6 @@ import com.triptune.domain.schedule.service.AttendeeService;
 import com.triptune.global.aop.AttendeeCheck;
 import com.triptune.global.response.ApiResponse;
 import com.triptune.global.response.pagination.ApiPageResponse;
-import com.triptune.global.response.pagination.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -46,10 +45,10 @@ public class AttendeeController {
 
     @DeleteMapping("/attendees")
     @Operation(summary = "일정 나가기", description = "일정에 참석자 목록에서 삭제됩니다.")
-    public ApiResponse<?> removeAttendee(@PathVariable(name = "scheduleId") Long scheduleId){
+    public ApiResponse<?> leaveScheduleAsGuest(@PathVariable(name = "scheduleId") Long scheduleId){
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        attendeeService.removeAttendee(scheduleId, userId);
+        attendeeService.leaveScheduleAsGuest(scheduleId, userId);
         return ApiResponse.okResponse();
     }
 

--- a/src/main/java/com/triptune/domain/schedule/controller/ChatController.java
+++ b/src/main/java/com/triptune/domain/schedule/controller/ChatController.java
@@ -35,15 +35,13 @@ public class ChatController {
 
     @MessageMapping("/chats")
     @Operation(summary = "채팅 보내기", description = "메시지를 저장하고 채팅 참가자들에게 메시지를 보낸다.")
-    public ApiResponse<?> sendChatMessage(@Valid @Payload ChatMessageRequest chatMessageRequest){
+    public void sendChatMessage(@Payload ChatMessageRequest chatMessageRequest){
         ChatResponse response = chatService.sendChatMessage(chatMessageRequest);
 
         messagingTemplate.convertAndSend(
-                "/sub/schedules" + chatMessageRequest.getScheduleId() + "/chats",
+                "/sub/schedules/" + chatMessageRequest.getScheduleId() + "/chats",
                 response
         );
-
-        return ApiResponse.okResponse();
     }
 
 }

--- a/src/main/java/com/triptune/domain/schedule/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/triptune/domain/schedule/dto/request/ChatMessageRequest.java
@@ -1,5 +1,6 @@
 package com.triptune.domain.schedule.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -17,6 +18,7 @@ public class ChatMessageRequest {
     private String nickname;
 
     @NotBlank(message = "메시지는 필수 입력 값입니다.")
+    @Max(1000)
     private String message;
 
     @Builder

--- a/src/main/java/com/triptune/domain/schedule/entity/TravelAttendee.java
+++ b/src/main/java/com/triptune/domain/schedule/entity/TravelAttendee.java
@@ -63,7 +63,4 @@ public class TravelAttendee {
                 .build();
     }
 
-    public boolean isAuthor(){
-        return AttendeeRole.AUTHOR.equals(this.role);
-    }
 }

--- a/src/main/java/com/triptune/domain/schedule/enumclass/AttendeePermission.java
+++ b/src/main/java/com/triptune/domain/schedule/enumclass/AttendeePermission.java
@@ -15,6 +15,6 @@ public enum AttendeePermission {
     private final String description;
 
     public boolean isEnableChat(){
-        return !this.equals(EDIT) && !this.equals(READ);
+        return this.equals(ALL) || this.equals(CHAT);
     }
 }

--- a/src/main/java/com/triptune/domain/schedule/enumclass/AttendeePermission.java
+++ b/src/main/java/com/triptune/domain/schedule/enumclass/AttendeePermission.java
@@ -1,5 +1,7 @@
 package com.triptune.domain.schedule.enumclass;
 
+import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
+import com.triptune.global.enumclass.ErrorCode;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -16,5 +18,8 @@ public enum AttendeePermission {
 
     public boolean isEnableChat(){
         return this.equals(ALL) || this.equals(CHAT);
+    }
+    public boolean isEnableEdit(){
+        return this.equals(ALL) || this.equals(EDIT);
     }
 }

--- a/src/main/java/com/triptune/domain/schedule/enumclass/AttendeeRole.java
+++ b/src/main/java/com/triptune/domain/schedule/enumclass/AttendeeRole.java
@@ -11,4 +11,8 @@ public enum AttendeeRole {
 
     private final int id;
     private final  String role;
+
+    public boolean isAuthor(){
+        return this == AUTHOR;
+    }
 }

--- a/src/main/java/com/triptune/domain/schedule/exception/ChatNotFoundException.java
+++ b/src/main/java/com/triptune/domain/schedule/exception/ChatNotFoundException.java
@@ -1,0 +1,15 @@
+package com.triptune.domain.schedule.exception;
+
+import com.triptune.global.enumclass.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ChatNotFoundException extends RuntimeException{
+    private final HttpStatus httpStatus;
+
+    public ChatNotFoundException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.httpStatus = errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/triptune/domain/schedule/exception/handler/ChatExceptionHandler.java
+++ b/src/main/java/com/triptune/domain/schedule/exception/handler/ChatExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.triptune.domain.schedule.exception.handler;
+
+import com.triptune.domain.schedule.exception.ChatNotFoundException;
+import com.triptune.domain.schedule.exception.ForbiddenChatException;
+import com.triptune.global.response.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ChatExceptionHandler {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageExceptionHandler
+    @SendToUser(destinations = "/queue/errors", broadcast = false)
+    public ErrorResponse handleForbiddenChatException(ForbiddenChatException ex){
+        log.error("ForbiddenChatException: {}", ex.getMessage());
+        return ErrorResponse.of(ex.getHttpStatus(), ex.getMessage());
+    }
+
+    @MessageExceptionHandler
+    @SendToUser(destinations = "/queue/errors", broadcast = false)
+    public ErrorResponse handleChatNotFoundException(ChatNotFoundException ex){
+        log.error("ChatNotFoundException: {}", ex.getMessage());
+        return ErrorResponse.of(ex.getHttpStatus(), ex.getMessage());
+    }
+
+}

--- a/src/main/java/com/triptune/domain/schedule/exception/handler/ScheduleExceptionHandler.java
+++ b/src/main/java/com/triptune/domain/schedule/exception/handler/ScheduleExceptionHandler.java
@@ -29,11 +29,5 @@ public class ScheduleExceptionHandler {
         return ErrorResponse.of(ex.getHttpStatus(), ex.getMessage());
     }
 
-    @ExceptionHandler
-    @ResponseStatus(HttpStatus.FORBIDDEN)
-    public ErrorResponse handleForbiddenChatException(ForbiddenChatException ex, HttpServletRequest request){
-        log.error("ForbiddenChatException at {}: {}", request.getRequestURI(), ex.getMessage());
-        return ErrorResponse.of(ex.getHttpStatus(), ex.getMessage());
-    }
 
 }

--- a/src/main/java/com/triptune/domain/schedule/repository/ChatMessageRepository.java
+++ b/src/main/java/com/triptune/domain/schedule/repository/ChatMessageRepository.java
@@ -5,6 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
     Page<ChatMessage> findChatByScheduleId(Pageable pageable, Long scheduleId);
+    List<ChatMessage> findAllByScheduleId(Long scheduleId);
+    void deleteAllByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
@@ -12,7 +12,6 @@ import com.triptune.domain.schedule.dto.response.ScheduleInfoResponse;
 import com.triptune.domain.schedule.entity.TravelAttendee;
 import com.triptune.domain.schedule.entity.TravelRoute;
 import com.triptune.domain.schedule.entity.TravelSchedule;
-import com.triptune.domain.schedule.enumclass.AttendeePermission;
 import com.triptune.domain.schedule.enumclass.AttendeeRole;
 import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
 import com.triptune.domain.schedule.repository.TravelAttendeeRepository;
@@ -158,7 +157,7 @@ public class ScheduleService {
         TravelSchedule travelSchedule = TravelSchedule.from(createScheduleRequest);
         TravelSchedule savedTravelSchedule = travelScheduleRepository.save(travelSchedule);
 
-        Member member = getSavedMember(userId);
+        Member member = getMemberByUserId(userId);
 
         TravelAttendee travelAttendee = TravelAttendee.of(savedTravelSchedule, member);
         travelAttendeeRepository.save(travelAttendee);
@@ -168,7 +167,7 @@ public class ScheduleService {
 
 
     public ScheduleDetailResponse getScheduleDetail(Long scheduleId, int page) {
-        TravelSchedule schedule = getSavedSchedule(scheduleId);
+        TravelSchedule schedule = getScheduleByScheduleId(scheduleId);
 
         // 여행지 정보: Page<TravelPlace> -> PageResponse<TravelSimpleResponse> 로 변경
         Pageable pageable = PageUtil.defaultPageable(page);
@@ -180,7 +179,7 @@ public class ScheduleService {
 
 
     public void updateSchedule(String userId, Long scheduleId, UpdateScheduleRequest updateScheduleRequest) {
-        TravelSchedule schedule = getSavedSchedule(scheduleId);
+        TravelSchedule schedule = getScheduleByScheduleId(scheduleId);
         TravelAttendee attendee = getAttendeeInfo(schedule, userId);
         checkUserPermission(attendee);
 
@@ -206,7 +205,7 @@ public class ScheduleService {
 
         if (routeRequestList != null && !routeRequestList.isEmpty()){
             for(RouteRequest routeRequest : routeRequestList){
-                TravelPlace place = getSavedPlace(routeRequest.getPlaceId());
+                TravelPlace place = getPlaceByPlaceId(routeRequest.getPlaceId());
                 TravelRoute route = TravelRoute.of(schedule, place, routeRequest.getRouteOrder());
                 schedule.getTravelRouteList().add(route);
                 travelRouteRepository.save(route);
@@ -226,18 +225,18 @@ public class ScheduleService {
         travelScheduleRepository.deleteById(scheduleId);
     }
 
-    public Member getSavedMember(String userId){
+    public Member getMemberByUserId(String userId){
         return memberRepository.findByUserId(userId)
                 .orElseThrow(() ->  new DataNotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 
-    public TravelSchedule getSavedSchedule(Long scheduleId){
+    public TravelSchedule getScheduleByScheduleId(Long scheduleId){
         return travelScheduleRepository.findByScheduleId(scheduleId)
                 .orElseThrow(() -> new DataNotFoundException(ErrorCode.SCHEDULE_NOT_FOUND));
     }
 
 
-    public TravelPlace getSavedPlace(Long placeId){
+    public TravelPlace getPlaceByPlaceId(Long placeId){
         return travelPlaceRepository.findByPlaceId(placeId)
                 .orElseThrow(() ->  new DataNotFoundException(ErrorCode.PLACE_NOT_FOUND));
     }

--- a/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triptune/domain/schedule/service/ScheduleService.java
@@ -49,12 +49,6 @@ public class ScheduleService {
     private final TravelRouteRepository travelRouteRepository;
 
 
-    /**
-     * 전체 일정 목록 조회
-     * @param page: 페이지 수
-     * @param userId: 접속 사용자 아이디
-     * @return SchedulePageResponse<ScheduleInfoResponse>: 사용자가 참석자로 포함되어있는 일정 목록들과 전제 일정 갯수, 공유된 일정 갯수가 포함된 dto
-     */
     public SchedulePageResponse<ScheduleInfoResponse> getSchedules(int page, String userId) {
         Pageable pageable = PageUtil.schedulePageable(page);
         Page<TravelSchedule> schedulePage = travelScheduleRepository.findTravelSchedulesByUserId(pageable, userId);
@@ -66,12 +60,7 @@ public class ScheduleService {
         return SchedulePageResponse.ofAll(scheduleInfoResponsePage, sharedScheduleCnt);
     }
 
-    /**
-     * 공유된 일정 목록 조회
-     * @param page: 페이지 수
-     * @param userId: 접속 사용자 아이디
-     * @return SchedulePageResponse<ScheduleInfoResponse>: 사용자가 참석자로 포함되어있는 일정 목록들과 전제 일정 갯수, 공유된 일정 갯수가 포함된 dto
-     */
+
     public SchedulePageResponse<ScheduleInfoResponse> getSharedSchedules(int page, String userId) {
         Pageable pageable = PageUtil.schedulePageable(page);
         Page<TravelSchedule> schedulePage = travelScheduleRepository.findSharedTravelSchedulesByUserId(pageable, userId);
@@ -84,14 +73,6 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 전체 일정 중 검색
-     * @param page: 페이지 수
-     * @param keyword: 검색 키워드
-     * @param userId: 접속 사용자 아이디
-     * @return SchedulePageResponse<ScheduleInfoResponse>: 사용자가 참석자로 포함되어있는 일정 목록들과 전제 일정 갯수, 공유된 일정 갯수가 포함된 dto
-
-     */
     public SchedulePageResponse<ScheduleInfoResponse> searchAllSchedules(int page, String keyword, String userId) {
         Pageable pageable = PageUtil.schedulePageable(page);
         Page<TravelSchedule> schedulesPage = travelScheduleRepository.searchTravelSchedulesByUserIdAndKeyword(pageable, keyword, userId);
@@ -104,13 +85,7 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 공유된 일정 중 검색
-     * @param page: 페이지 수
-     * @param keyword: 검색 키워드
-     * @param userId: 접속 사용자 아이디
-     * @return SchedulePageResponse<ScheduleInfoResponse>: 사용자가 참석자로 포함되어있는 일정 목록들과 전제 일정 갯수, 공유된 일정 갯수가 포함된 dto
-     */
+
     public SchedulePageResponse<ScheduleInfoResponse> searchSharedSchedules(int page, String keyword, String userId) {
         Pageable pageable = PageUtil.schedulePageable(page);
         Page<TravelSchedule> schedulesPage = travelScheduleRepository.searchSharedTravelSchedulesByUserIdAndKeyword(pageable, keyword, userId);
@@ -123,12 +98,6 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 일정 목록 조회에서 사용할 dto 생성
-     * @param schedulePage: Page 객체에 담겨있는 일정들
-     * @param userId: 접속한 사용자 아이디
-     * @return List<ScheduleInfoResponse>: 일정 목록에서 사용할 정보들이 담긴 dto 리스트
-     */
     public List<ScheduleInfoResponse> createScheduleInfoResponse(Page<TravelSchedule> schedulePage, String userId){
         if (schedulePage.getContent().isEmpty()){
             return Collections.emptyList();
@@ -146,11 +115,6 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 일정의 작성자 dto 생성 메소드
-     * @param schedule: 일정
-     * @return AuthorDTO: 작성자 정보 포함된 dto
-     */
     public AuthorDTO createAuthorDTO(TravelSchedule schedule){
         Member author = schedule.getTravelAttendeeList().stream()
                 .filter(attendee -> attendee.getRole().equals(AttendeeRole.AUTHOR))
@@ -161,12 +125,7 @@ public class ScheduleService {
         return AuthorDTO.of(author.getNickname(), author.getProfileImage().getS3ObjectUrl());
     }
 
-    /**
-     * 일정 참석자 정보 조회
-     * @param schedule: 일정 객체
-     * @param userId: 사용자 아이디
-     * @return TravelAttendee: 조회한 사용자의 일정 권한 및 허용 범위 포함된 객체
-     */
+
     public TravelAttendee getAttendeeInfo(TravelSchedule schedule, String userId){
         return schedule.getTravelAttendeeList().stream()
                 .filter(attendee -> attendee.getMember().getUserId().equals(userId))
@@ -175,11 +134,7 @@ public class ScheduleService {
 
     }
 
-    /**
-     * 썸네일 이미지 조회
-     * @param schedule: 일정
-     * @return String: 썸네일 url
-     */
+
     public String getThumbnailUrl(TravelSchedule schedule){
         String thumbnailUrl = null;
         List<TravelRoute> travelRouteList = schedule.getTravelRouteList();
@@ -199,12 +154,6 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 일정 생성
-     * @param createScheduleRequest: 일정명, 날짜 등 포함된 dto
-     * @param userId: 사용자 아이디
-     * @return CreateScheduleResponse: scheduleId로 구성된 dto
-     */
     public CreateScheduleResponse createSchedule(CreateScheduleRequest createScheduleRequest, String userId){
         TravelSchedule travelSchedule = TravelSchedule.from(createScheduleRequest);
         TravelSchedule savedTravelSchedule = travelScheduleRepository.save(travelSchedule);
@@ -217,12 +166,7 @@ public class ScheduleService {
         return CreateScheduleResponse.from(savedTravelSchedule);
     }
 
-    /**
-     * 일정 상세 조회
-     * @param scheduleId: 일정 인덱스
-     * @param page: 페이지 수
-     * @return ScheduleResponse: 일정 정보, 여행지 정보(중구)로 구성된 dto
-     */
+
     public ScheduleDetailResponse getScheduleDetail(Long scheduleId, int page) {
         TravelSchedule schedule = getSavedSchedule(scheduleId);
 
@@ -235,30 +179,26 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 일정 수정
-     * @param userId: 사용자 아이디
-     * @param scheduleId: 일정 인덱스
-     * @param updateScheduleRequest: 수정 일정 dto
-     */
     public void updateSchedule(String userId, Long scheduleId, UpdateScheduleRequest updateScheduleRequest) {
         TravelSchedule schedule = getSavedSchedule(scheduleId);
         TravelAttendee attendee = getAttendeeInfo(schedule, userId);
-        checkUserPermission(attendee.getPermission());
+        checkUserPermission(attendee);
 
         schedule.set(updateScheduleRequest);
         updateTravelRouteInSchedule(schedule, updateScheduleRequest.getTravelRoute());
     }
 
-    /**
-     * 일정 수정 중 여행 루트 수정
-     * @param schedule: 일정 객체
-     * @param routeRequestList: 수정할 여행 루트
-     */
+    public void checkUserPermission(TravelAttendee attendee){
+        if (!attendee.getPermission().isEnableEdit()){
+            throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_EDIT_SCHEDULE);
+        }
+    }
+
+
     public void updateTravelRouteInSchedule(TravelSchedule schedule, List<RouteRequest> routeRequestList){
         travelRouteRepository.deleteAllByTravelSchedule_ScheduleId(schedule.getScheduleId());
 
-        if (schedule.getTravelRouteList() == null) {
+        if (schedule.getTravelRouteList() == null){
             schedule.setTravelRouteList(new ArrayList<>());
         } else{
             schedule.getTravelRouteList().clear();
@@ -275,57 +215,28 @@ public class ScheduleService {
     }
 
 
-    /**
-     * 사용자의 일정 허용 범위 체크
-     * @param permission: 허용 범위
-     */
-    public void checkUserPermission(AttendeePermission permission){
-        if (permission.equals(AttendeePermission.CHAT) || permission.equals(AttendeePermission.READ)){
-            throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_EDIT_SCHEDULE);
-        }
-    }
-
-    /**
-     * 일정 삭제
-     * @param scheduleId: 일정 인덱스
-     * @param userId: 사용자 아이디
-     */
     public void deleteSchedule(Long scheduleId, String userId) {
         TravelAttendee attendee = travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(scheduleId, userId)
                 .orElseThrow(() -> new ForbiddenScheduleException(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE));
 
-        if (!attendee.isAuthor()){
+        if (!attendee.getRole().isAuthor()){
             throw new ForbiddenScheduleException(ErrorCode.FORBIDDEN_DELETE_SCHEDULE);
         }
 
         travelScheduleRepository.deleteById(scheduleId);
     }
 
-    /**
-     * 저장된 사용자 정보 조회
-     * @param userId: 사용자 아이디
-     * @return Member: 사용자 entity
-     */
     public Member getSavedMember(String userId){
         return memberRepository.findByUserId(userId)
                 .orElseThrow(() ->  new DataNotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 
-    /**
-     * 저장된 일정 조회
-     * @param scheduleId: 일정 인덱스
-     * @return TravelSchedule: 일정 entity
-     */
     public TravelSchedule getSavedSchedule(Long scheduleId){
         return travelScheduleRepository.findByScheduleId(scheduleId)
                 .orElseThrow(() -> new DataNotFoundException(ErrorCode.SCHEDULE_NOT_FOUND));
     }
 
-    /**
-     * 저장된 여행지 조회
-     * @param placeId: 여행지 인덱스
-     * @return TravelPlace: 여행지 entity
-     */
+
     public TravelPlace getSavedPlace(Long placeId){
         return travelPlaceRepository.findByPlaceId(placeId)
                 .orElseThrow(() ->  new DataNotFoundException(ErrorCode.PLACE_NOT_FOUND));

--- a/src/main/java/com/triptune/global/config/WebSocketConfig.java
+++ b/src/main/java/com/triptune/global/config/WebSocketConfig.java
@@ -19,9 +19,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 메시지 구독하는 요청 엔드포인트
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker("/sub", "/queue");
         // 메시지를 발송하는 엔드포인트
         registry.setApplicationDestinationPrefixes("/pub");
+        // 사용자 대상 프리픽스 추가
+        registry.setUserDestinationPrefix("/user");
     }
 
 

--- a/src/main/java/com/triptune/global/util/StompHandler.java
+++ b/src/main/java/com/triptune/global/util/StompHandler.java
@@ -1,6 +1,7 @@
 package com.triptune.global.util;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -8,6 +9,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class StompHandler implements ChannelInterceptor {
@@ -19,9 +21,12 @@ public class StompHandler implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
         if (StompCommand.CONNECT == accessor.getCommand()) {
+            log.info("WebSocket 연결 요청: {}", accessor.getSessionId());
 
             String token = jwtUtil.resolveBearerToken(accessor.getFirstNativeHeader("Authorization"));
             jwtUtil.validateToken(token);
+
+            log.info("WebSocket 연결 완료: {}", accessor.getSessionId());
         }
 
         return message;

--- a/src/test/java/com/triptune/domain/BaseTest.java
+++ b/src/test/java/com/triptune/domain/BaseTest.java
@@ -135,12 +135,12 @@ public abstract class BaseTest {
                 .build();
     }
 
-    protected ChatMessage createChatMessage(String messageId, Long scheduleId, Long memberId, String nickname, String message){
+    protected ChatMessage createChatMessage(String messageId, Long scheduleId, Member member, String message){
         return ChatMessage.builder()
                 .messageId(messageId)
                 .scheduleId(scheduleId)
-                .memberId(memberId)
-                .nickname(nickname)
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
                 .message(message)
                 .timestamp(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/AttendeeControllerTest.java
@@ -199,9 +199,9 @@ public class AttendeeControllerTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거")
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거")
     @WithMockUser(username = "member2")
-    void removeAttendee() throws Exception {
+    void leaveScheduleAsGuest() throws Exception {
         mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule1.getScheduleId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
@@ -210,9 +210,9 @@ public class AttendeeControllerTest extends ScheduleTest {
 
 
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
     @WithMockUser(username = "member1")
-    void removeAttendeeIsAuthor_forbiddenScheduleException() throws Exception {
+    void leaveScheduleAsGuestIsAuthor_forbiddenScheduleException() throws Exception {
         mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule1.getScheduleId()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))
@@ -220,9 +220,9 @@ public class AttendeeControllerTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 일정에 접근 권한이 없어 예외 발생")
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거 시 사용자가 일정에 접근 권한이 없어 예외 발생")
     @WithMockUser(username = "member1")
-    void removeAttendeeNotAttendee_forbiddenScheduleException() throws Exception {
+    void leaveScheduleAsGuest_forbiddenScheduleException() throws Exception {
         mockMvc.perform(delete("/api/schedules/{scheduleId}/attendees", schedule2.getScheduleId()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.success").value(false))

--- a/src/test/java/com/triptune/domain/schedule/controller/ChatControllerTest.java
+++ b/src/test/java/com/triptune/domain/schedule/controller/ChatControllerTest.java
@@ -98,12 +98,12 @@ public class ChatControllerTest extends ScheduleTest {
     @DisplayName("getChatMessages(): 대화 내용 조회")
     @WithMockUser(username = "member1")
     void getChatMessages() throws Exception {
-        ChatMessage message1 = chatMessageRepository.save(createChatMessage("id1", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello1"));
-        ChatMessage message2 = chatMessageRepository.save(createChatMessage("id2", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello2"));
-        ChatMessage message3 = chatMessageRepository.save(createChatMessage("id3", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello3"));
-        ChatMessage message4 = chatMessageRepository.save(createChatMessage("id4", schedule.getScheduleId(), member2.getMemberId(), member2.getNickname(), "hello4"));
-        ChatMessage message5 = chatMessageRepository.save(createChatMessage("id5", schedule.getScheduleId(), member3.getMemberId(), member3.getNickname(), "hello5"));
-        ChatMessage message6 = chatMessageRepository.save(createChatMessage("id6", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello6"));
+        ChatMessage message1 = chatMessageRepository.save(createChatMessage("id1", schedule.getScheduleId(), member1, "hello1"));
+        ChatMessage message2 = chatMessageRepository.save(createChatMessage("id2", schedule.getScheduleId(), member1, "hello2"));
+        ChatMessage message3 = chatMessageRepository.save(createChatMessage("id3", schedule.getScheduleId(), member1, "hello3"));
+        ChatMessage message4 = chatMessageRepository.save(createChatMessage("id4", schedule.getScheduleId(), member2, "hello4"));
+        ChatMessage message5 = chatMessageRepository.save(createChatMessage("id5", schedule.getScheduleId(), member3, "hello5"));
+        ChatMessage message6 = chatMessageRepository.save(createChatMessage("id6", schedule.getScheduleId(), member1, "hello6"));
 
         mockMvc.perform(get("/api/schedules/{scheduleId}/chats", schedule.getScheduleId())
                         .param("page", "1"))

--- a/src/test/java/com/triptune/domain/schedule/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/triptune/domain/schedule/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.triptune.domain.schedule.repository;
+
+import com.triptune.domain.member.entity.Member;
+import com.triptune.domain.member.repository.MemberRepository;
+import com.triptune.domain.schedule.ScheduleTest;
+import com.triptune.domain.schedule.entity.ChatMessage;
+import com.triptune.domain.schedule.entity.TravelSchedule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("mongo")
+public class ChatMessageRepositoryTest extends ScheduleTest {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository;
+    private final TravelScheduleRepository travelScheduleRepository;
+
+    @Autowired
+    public ChatMessageRepositoryTest(ChatMessageRepository chatMessageRepository, MemberRepository memberRepository, TravelScheduleRepository travelScheduleRepository) {
+        this.chatMessageRepository = chatMessageRepository;
+        this.memberRepository = memberRepository;
+        this.travelScheduleRepository = travelScheduleRepository;
+    }
+
+    private TravelSchedule schedule;
+
+    @BeforeEach
+    void setUp(){
+        chatMessageRepository.deleteAll();
+        schedule = travelScheduleRepository.save(createTravelSchedule(null, "테스트"));
+    }
+
+
+    @Test
+    @DisplayName("findAllByScheduleId(): 일정 인덱스를 통해 채팅 목록 조회")
+    void findAllByScheduleId(){
+        // given
+        Member member1 = memberRepository.save(createMember(null, "member1"));
+        Member member2 = memberRepository.save(createMember(null, "member2"));
+        ChatMessage message1 = chatMessageRepository.save(createChatMessage("chat1", schedule.getScheduleId(), member1, "hello1"));
+        ChatMessage message2 = chatMessageRepository.save(createChatMessage("chat2", schedule.getScheduleId(), member1, "hello2"));
+        ChatMessage message3 = chatMessageRepository.save(createChatMessage("chat3", schedule.getScheduleId(), member2, "hello3"));
+
+        // when
+        List<ChatMessage> response = chatMessageRepository.findAllByScheduleId(schedule.getScheduleId());
+
+        // then
+        assertEquals(response.size(), 3);
+        assertEquals(response.get(0).getMessage(), message1.getMessage());
+        assertEquals(response.get(1).getMessage(), message2.getMessage());
+        assertEquals(response.get(2).getMessage(), message3.getMessage());
+    }
+
+    @Test
+    @DisplayName("findAllByScheduleId(): 일정 인덱스를 통해 채팅 목록 조회")
+    void findAllByScheduleId_isEmpty(){
+        // given, when
+        List<ChatMessage> response = chatMessageRepository.findAllByScheduleId(schedule.getScheduleId());
+
+        // then
+        assertEquals(response.size(), 0);
+    }
+
+    @Test
+    @DisplayName("deleteAllByScheduleId(): 일정 인덱스를 통해 채팅 삭제")
+    void deleteAllByScheduleId(){
+        // given
+        Member member1 = memberRepository.save(createMember(null, "member1"));
+        Member member2 = memberRepository.save(createMember(null, "member2"));
+        chatMessageRepository.save(createChatMessage("chat1", schedule.getScheduleId(), member1, "hello1"));
+        chatMessageRepository.save(createChatMessage("chat2", schedule.getScheduleId(), member1, "hello2"));
+        chatMessageRepository.save(createChatMessage("chat3", schedule.getScheduleId(), member2, "hello3"));
+
+
+        // when
+        chatMessageRepository.deleteAllByScheduleId(schedule.getScheduleId());
+
+        // then
+        List<ChatMessage> chatMessages = chatMessageRepository.findAllByScheduleId(schedule.getScheduleId());
+        assertTrue(chatMessages.isEmpty());
+    }
+
+
+    @Test
+    @DisplayName("deleteAllByScheduleId(): 일정 인덱스를 통해 채팅 삭제 시 채팅 데이터 없는 경우")
+    void deleteAllByScheduleId_NoData(){
+        // given, when
+        chatMessageRepository.deleteAllByScheduleId(schedule.getScheduleId());
+
+        // then
+        List<ChatMessage> chatMessages = chatMessageRepository.findAllByScheduleId(schedule.getScheduleId());
+        assertTrue(chatMessages.isEmpty());
+    }
+
+}

--- a/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/AttendeeServiceTest.java
@@ -25,11 +25,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -200,28 +198,27 @@ public class AttendeeServiceTest extends ScheduleTest {
     }
 
 
-
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거")
-    void removeAttendee(){
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거")
+    void leaveScheduleAsGuest(){
         // given
         when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee2));
 
         // when
-        attendeeService.removeAttendee(schedule1.getScheduleId(), member2.getUserId());
+        attendeeService.leaveScheduleAsGuest(schedule1.getScheduleId(), member2.getUserId());
 
         // then
         verify(travelAttendeeRepository, times(1)).deleteById(any());
     }
 
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거 시 참가자 정보가 없어 예외 발생")
-    void removeAttendeeNoAttendeeData_forbiddenScheduleException(){
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거 시 참가자 정보가 없어 예외 발생")
+    void leaveScheduleAsGuest_forbiddenScheduleException(){
         // given
         when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.empty());
 
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule1.getScheduleId(), member1.getUserId()));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.leaveScheduleAsGuest(schedule1.getScheduleId(), member1.getUserId()));
 
         // then
         assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());
@@ -229,13 +226,13 @@ public class AttendeeServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("removeAttendee(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
-    void removeAttendeeIsAuthor_forbiddenScheduleException(){
+    @DisplayName("leaveScheduleAsGuest(): 일정 참석자 제거 시 사용자가 작성자여서 예외 발생")
+    void leaveScheduleAsGuestIsAuthor_forbiddenScheduleException(){
         // given
         when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.of(attendee1));
 
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.removeAttendee(schedule1.getScheduleId(), member1.getUserId()));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> attendeeService.leaveScheduleAsGuest(schedule1.getScheduleId(), member1.getUserId()));
 
         // then
         assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.FORBIDDEN_REMOVE_ATTENDEE.getStatus());

--- a/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
@@ -11,6 +11,7 @@ import com.triptune.domain.schedule.entity.TravelAttendee;
 import com.triptune.domain.schedule.entity.TravelSchedule;
 import com.triptune.domain.schedule.enumclass.AttendeePermission;
 import com.triptune.domain.schedule.enumclass.AttendeeRole;
+import com.triptune.domain.schedule.exception.ChatNotFoundException;
 import com.triptune.domain.schedule.exception.ForbiddenChatException;
 import com.triptune.domain.schedule.exception.ForbiddenScheduleException;
 import com.triptune.domain.schedule.repository.ChatMessageRepository;
@@ -329,7 +330,7 @@ class ChatServiceTest extends ScheduleTest {
         when(memberRepository.findByNickname(anyString())).thenReturn(Optional.empty());
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> chatService.getChatMemberByNickname(member1.getNickname()));
+        ChatNotFoundException fail = assertThrows(ChatNotFoundException.class, () -> chatService.getChatMemberByNickname(member1.getNickname()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.USER_NOT_FOUND.getStatus());
@@ -363,7 +364,7 @@ class ChatServiceTest extends ScheduleTest {
         when(travelAttendeeRepository.findByTravelSchedule_ScheduleIdAndMember_UserId(anyLong(), anyString())).thenReturn(Optional.empty());
 
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> chatService.getTravelAttendee(schedule.getScheduleId(), member1.getUserId()));
+        ForbiddenChatException fail = assertThrows(ForbiddenChatException.class, () -> chatService.getTravelAttendee(schedule.getScheduleId(), member1.getUserId()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.FORBIDDEN_ACCESS_SCHEDULE.getStatus());

--- a/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
@@ -80,12 +80,12 @@ class ChatServiceTest extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.chatPageable(1);
 
-        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello1");
-        ChatMessage message2 = createChatMessage("id2", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello2");
-        ChatMessage message3 = createChatMessage("id3", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello3");
-        ChatMessage message4 = createChatMessage("id4", schedule.getScheduleId(), member2.getMemberId(), member2.getNickname(), "hello4");
-        ChatMessage message5 = createChatMessage("id5", schedule.getScheduleId(), member3.getMemberId(), member3.getNickname(), "hello5");
-        ChatMessage message6 = createChatMessage("id6", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello6");
+        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1, "hello1");
+        ChatMessage message2 = createChatMessage("id2", schedule.getScheduleId(), member1, "hello2");
+        ChatMessage message3 = createChatMessage("id3", schedule.getScheduleId(), member1, "hello3");
+        ChatMessage message4 = createChatMessage("id4", schedule.getScheduleId(), member2, "hello4");
+        ChatMessage message5 = createChatMessage("id5", schedule.getScheduleId(), member3, "hello5");
+        ChatMessage message6 = createChatMessage("id6", schedule.getScheduleId(), member1, "hello6");
         List<ChatMessage> messageList = new ArrayList<>(List.of(message1, message2, message3, message4, message5, message6));
         Page<ChatMessage> chatPage = PageUtil.createPage(messageList, pageable, messageList.size());
 
@@ -124,9 +124,9 @@ class ChatServiceTest extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.chatPageable(1);
 
-        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello1");
-        ChatMessage message2 = createChatMessage("id2", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello2");
-        ChatMessage message3 = createChatMessage("id3", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello3");
+        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1, "hello1");
+        ChatMessage message2 = createChatMessage("id2", schedule.getScheduleId(), member1, "hello2");
+        ChatMessage message3 = createChatMessage("id3", schedule.getScheduleId(), member1, "hello3");
 
         List<ChatMessage> messageList = new ArrayList<>(List.of(message1, message2, message3));
         Page<ChatMessage> chatPage = PageUtil.createPage(messageList, pageable, messageList.size());
@@ -151,9 +151,9 @@ class ChatServiceTest extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.chatPageable(1);
 
-        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello1");
-        ChatMessage message2 = createChatMessage("id4", schedule.getScheduleId(), member2.getMemberId(), member2.getNickname(), "hello2");
-        ChatMessage message3 = createChatMessage("id5", schedule.getScheduleId(), member3.getMemberId(), member3.getNickname(), "hello3");
+        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1, "hello1");
+        ChatMessage message2 = createChatMessage("id4", schedule.getScheduleId(), member2, "hello2");
+        ChatMessage message3 = createChatMessage("id5", schedule.getScheduleId(), member3, "hello3");
         List<ChatMessage> messageList = new ArrayList<>(List.of(message1, message2, message3));
         Page<ChatMessage> chatPage = PageUtil.createPage(messageList, pageable, messageList.size());
 
@@ -205,7 +205,7 @@ class ChatServiceTest extends ScheduleTest {
         // given
         Pageable pageable = PageUtil.chatPageable(1);
 
-        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1.getMemberId(), member1.getNickname(), "hello1");
+        ChatMessage message1 = createChatMessage("id1", schedule.getScheduleId(), member1, "hello1");
         List<ChatMessage> messageList = new ArrayList<>(List.of(message1));
         Page<ChatMessage> chatPage = PageUtil.createPage(messageList, pageable, messageList.size());
 

--- a/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ChatServiceTest.java
@@ -309,12 +309,12 @@ class ChatServiceTest extends ScheduleTest {
 
     @Test
     @DisplayName("getMemberByNickname(): 닉네임으로 사용자 정보 조회")
-    void getMemberByNickname(){
+    void getChatMemberByNickname(){
         // given
         when(memberRepository.findByNickname(anyString())).thenReturn(Optional.of(member1));
 
         // when
-        Member response = chatService.getMemberByNickname(member1.getNickname());
+        Member response = chatService.getChatMemberByNickname(member1.getNickname());
 
         // then
         assertEquals(response.getUserId(), member1.getUserId());
@@ -324,12 +324,12 @@ class ChatServiceTest extends ScheduleTest {
 
     @Test
     @DisplayName("getMemberByNickname(): 닉네임으로 사용자 정보 조회 시 데이터 없어 예외 발생")
-    void getMemberByNickname_dataNotFoundException(){
+    void getChatMemberByNickname_dataNotFoundException(){
         // given
         when(memberRepository.findByNickname(anyString())).thenReturn(Optional.empty());
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> chatService.getMemberByNickname(member1.getNickname()));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> chatService.getChatMemberByNickname(member1.getNickname()));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.USER_NOT_FOUND.getStatus());

--- a/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
@@ -1012,31 +1012,31 @@ public class ScheduleServiceTest extends ScheduleTest {
     @DisplayName("checkUserPermission(): 사용자 편집 권한 중 ALL")
     void checkUserPermissionALL(){
         // given
-        AttendeePermission permission = AttendeePermission.ALL;
+        attendee1.setPermission(AttendeePermission.ALL);
 
         // when, then
-        assertDoesNotThrow(() -> scheduleService.checkUserPermission(permission));
+        assertDoesNotThrow(() -> scheduleService.checkUserPermission(attendee1));
     }
 
     @Test
     @DisplayName("checkUserPermission(): 사용자 편집 권한 중 EDIT")
     void checkUserPermissionEdit(){
         // given
-        AttendeePermission permission = AttendeePermission.EDIT;
+        attendee1.setPermission(AttendeePermission.EDIT);
 
         // when
         // then
-        assertDoesNotThrow(() -> scheduleService.checkUserPermission(permission));
+        assertDoesNotThrow(() -> scheduleService.checkUserPermission(attendee1));
     }
 
     @Test
     @DisplayName("checkUserPermission(): 사용자 편집 권한 체크 시 CHAT 권한으로 예외 발생")
     void checkUserPermissionCHAT_forbiddenScheduleException(){
         // given
-        AttendeePermission permission = AttendeePermission.CHAT;
+        attendee1.setPermission(AttendeePermission.CHAT);
 
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.checkUserPermission(permission));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.checkUserPermission(attendee1));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.FORBIDDEN_EDIT_SCHEDULE.getStatus());
@@ -1047,10 +1047,10 @@ public class ScheduleServiceTest extends ScheduleTest {
     @DisplayName("checkUserPermission(): 사용자 편집 권한 체크 시 READ 권한으로 예외 발생")
     void checkUserPermissionREAD_forbiddenScheduleException(){
         // given
-        AttendeePermission permission = AttendeePermission.READ;
+        attendee1.setPermission(AttendeePermission.READ);
 
         // when
-        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.checkUserPermission(permission));
+        ForbiddenScheduleException fail = assertThrows(ForbiddenScheduleException.class, () -> scheduleService.checkUserPermission(attendee1));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.FORBIDDEN_EDIT_SCHEDULE.getStatus());

--- a/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/triptune/domain/schedule/service/ScheduleServiceTest.java
@@ -1082,15 +1082,15 @@ public class ScheduleServiceTest extends ScheduleTest {
 
 
     @Test
-    @DisplayName("getSavedMember(): 저장된 사용자 정보 조회")
-    void getSavedMember(){
+    @DisplayName("getMemberByUserId(): 저장된 사용자 정보 조회")
+    void getMemberByUserId(){
         // given
         String userId = "member1";
 
         when(memberRepository.findByUserId(any())).thenReturn(Optional.of(member1));
 
         // when
-        Member response = scheduleService.getSavedMember(userId);
+        Member response = scheduleService.getMemberByUserId(userId);
 
         // then
         assertEquals(response.getUserId(), userId);
@@ -1100,13 +1100,13 @@ public class ScheduleServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSavedMember(): 저장된 사용자 정보 조회 시 데이터 찾을 수 없어 예외 발생")
-    void getSavedMember_dataNotFoundException(){
+    @DisplayName("getMemberByUserId(): 저장된 사용자 정보 조회 시 데이터 찾을 수 없어 예외 발생")
+    void getMember_ByUserId_dataNotFoundException(){
         // given
         when(memberRepository.findByUserId(any())).thenReturn(Optional.empty());
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getSavedMember("notUser"));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getMemberByUserId("notUser"));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.USER_NOT_FOUND.getStatus());
@@ -1114,13 +1114,13 @@ public class ScheduleServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSavedSchedule(): 저장된 일정 조회")
-    void getSavedSchedule(){
+    @DisplayName("getScheduleByScheduleId(): 저장된 일정 조회")
+    void getScheduleByScheduleId(){
         // given
         when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.of(schedule1));
 
         // when
-        TravelSchedule response = scheduleService.getSavedSchedule(schedule1.getScheduleId());
+        TravelSchedule response = scheduleService.getScheduleByScheduleId(schedule1.getScheduleId());
 
         // then
         assertEquals(response.getScheduleName(), schedule1.getScheduleName());
@@ -1129,13 +1129,13 @@ public class ScheduleServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSavedSchedule(): 저장된 일정 조회 시 데이터 찾을 수 없어 예외 발생")
-    void getSavedSchedule_dataNotFoundException(){
+    @DisplayName("getScheduleByScheduleId(): 저장된 일정 조회 시 데이터 찾을 수 없어 예외 발생")
+    void getScheduleBySchedule_Id_dataNotFoundException(){
         // given
         when(travelScheduleRepository.findByScheduleId(any())).thenReturn(Optional.empty());
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getSavedSchedule(0L));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getScheduleByScheduleId(0L));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.SCHEDULE_NOT_FOUND.getStatus());
@@ -1143,15 +1143,15 @@ public class ScheduleServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSavedPlace(): 저장된 여행지 조회 성공")
-    void getSavedPlace(){
+    @DisplayName("getPlaceByPlaceId(): 저장된 여행지 조회 성공")
+    void getPlaceByPlaceId(){
         // given
         Long placeId = travelPlace1.getPlaceId();
 
         when(travelPlaceRepository.findByPlaceId(anyLong())).thenReturn(Optional.of(travelPlace1));
 
         // when
-        TravelPlace response = scheduleService.getSavedPlace(placeId);
+        TravelPlace response = scheduleService.getPlaceByPlaceId(placeId);
 
         // then
         assertEquals(response.getPlaceId(), placeId);
@@ -1160,15 +1160,15 @@ public class ScheduleServiceTest extends ScheduleTest {
     }
 
     @Test
-    @DisplayName("getSavedPlace(): 여행지가 존재하지 않아 예외 발생")
-    void getSavedPlaceNoTravelPlace_dataNotFoundException(){
+    @DisplayName("getPlaceByPlaceId(): 여행지가 존재하지 않아 예외 발생")
+    void getPlaceByPlaceNoTravelPlace_Id_dataNotFoundException(){
         // given
         Long placeId = travelPlace1.getPlaceId();
 
         when(travelPlaceRepository.findByPlaceId(anyLong())).thenReturn(Optional.empty());
 
         // when
-        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getSavedPlace(placeId));
+        DataNotFoundException fail = assertThrows(DataNotFoundException.class, () -> scheduleService.getPlaceByPlaceId(placeId));
 
         // then
         assertEquals(fail.getHttpStatus(), ErrorCode.PLACE_NOT_FOUND.getStatus());


### PR DESCRIPTION
## 변경 내용
- #13 
1. 채팅 예외 처리 수정
: 채팅의 경우 HTTP 통신이 아니기 때문에 기존에 사용하던 예외 처리 방식으로는 프론트에 예외 전달 불가해 STOMP 메시지를 통해서 예외 메시지가 전달되게 변경 
-> 추후 프론트 개발 후 테스트 필수

- #12
1. 일정 삭제 시 채팅 메시지도 삭제되게 수정

<br>

## 리팩토링 내용
- #4 
1. 권한 체크 로직 ENUM 에 추가
2. 함수명 변경