### PR TITLE
[update] 채팅 데이터 저장 시 닉네임 제외 #13

### DIFF
--- a/src/main/java/com/triptune/domain/schedule/entity/ChatMessage.java
+++ b/src/main/java/com/triptune/domain/schedule/entity/ChatMessage.java
@@ -20,16 +20,14 @@ public class ChatMessage {
     private String messageId;
     private Long scheduleId;
     private Long memberId;
-    private String nickname;
     private String message;
     private LocalDateTime timestamp;
 
     @Builder
-    public ChatMessage(String messageId, Long scheduleId, Long memberId, String nickname, String message, LocalDateTime timestamp) {
+    public ChatMessage(String messageId, Long scheduleId, Long memberId, String message, LocalDateTime timestamp) {
         this.messageId = messageId;
         this.scheduleId = scheduleId;
         this.memberId = memberId;
-        this.nickname = nickname;
         this.message = message;
         this.timestamp = timestamp;
     }
@@ -38,7 +36,6 @@ public class ChatMessage {
         return ChatMessage.builder()
                 .scheduleId(chatMessageRequest.getScheduleId())
                 .memberId(member.getMemberId())
-                .nickname(member.getNickname())
                 .message(chatMessageRequest.getMessage())
                 .timestamp(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/triptune/domain/BaseTest.java
+++ b/src/test/java/com/triptune/domain/BaseTest.java
@@ -192,7 +192,6 @@ public abstract class BaseTest {
                 .messageId(messageId)
                 .scheduleId(scheduleId)
                 .memberId(member.getMemberId())
-                .nickname(member.getNickname())
                 .message(message)
                 .timestamp(LocalDateTime.now())
                 .build();


### PR DESCRIPTION
## 수정 구현
- #13 
1. 채팅 데이터 저장 시 닉네임 데이터 제외하고 저장