### PR TITLE
[feat&update] 간편 로그인과 자체 로그인 관리 수정  #168

### DIFF
--- a/src/main/java/com/triptune/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/triptune/global/security/oauth/CustomOAuth2UserService.java
@@ -8,6 +8,7 @@ import com.triptune.global.security.oauth.userinfo.KaKaoUserInfo;
 import com.triptune.global.security.oauth.userinfo.NaverUserInfo;
 import com.triptune.global.security.oauth.userinfo.OAuth2UserInfo;
 import com.triptune.global.security.jwt.JwtUtils;
+import com.triptune.global.util.NicknameGenerator;
 import com.triptune.member.entity.Member;
 import com.triptune.member.entity.SocialMember;
 import com.triptune.member.enums.JoinType;
@@ -36,6 +37,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final ProfileImageService profileImageService;
     private final SocialMemberRepository socialMemberRepository;
     private final JwtUtils jwtUtils;
+    private final NicknameGenerator nicknameGenerator;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -96,10 +98,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     public Member createMember(OAuth2UserInfo oAuth2UserInfo){
-        validateUniqueNickname(oAuth2UserInfo.getNickname());
+        String nickname = nicknameGenerator.createNickname();
 
         ProfileImage profileImage = profileImageService.saveDefaultProfileImage();
-        Member member = Member.from(profileImage, oAuth2UserInfo);
+        Member member = Member.from(profileImage, oAuth2UserInfo, nickname);
         Member newMember = memberRepository.save(member);
 
         createSocialMember(newMember, oAuth2UserInfo);
@@ -114,9 +116,4 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         socialMemberRepository.save(socialMember);
     }
 
-    public void validateUniqueNickname(String nickname){
-        if(memberRepository.existsByNickname(nickname)){
-            throw new DataExistException(ErrorCode.ALREADY_EXISTED_NICKNAME);
-        }
-    }
 }

--- a/src/main/java/com/triptune/global/security/oauth/userinfo/KaKaoUserInfo.java
+++ b/src/main/java/com/triptune/global/security/oauth/userinfo/KaKaoUserInfo.java
@@ -26,8 +26,4 @@ public class KaKaoUserInfo implements OAuth2UserInfo{
         return "";
     }
 
-    @Override
-    public String getNickname() {
-        return "";
-    }
 }

--- a/src/main/java/com/triptune/global/security/oauth/userinfo/NaverUserInfo.java
+++ b/src/main/java/com/triptune/global/security/oauth/userinfo/NaverUserInfo.java
@@ -26,9 +26,5 @@ public class NaverUserInfo implements OAuth2UserInfo{
         return attributes.get("email").toString();
     }
 
-    @Override
-    public String getNickname() {
-        return attributes.get("nickname").toString();
-    }
 
 }

--- a/src/main/java/com/triptune/global/security/oauth/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/triptune/global/security/oauth/userinfo/OAuth2UserInfo.java
@@ -6,6 +6,5 @@ public interface OAuth2UserInfo {
     String getSocialId();
     SocialType getSocialType();
     String getEmail();
-    String getNickname();
 
 }

--- a/src/main/java/com/triptune/global/util/NicknameGenerator.java
+++ b/src/main/java/com/triptune/global/util/NicknameGenerator.java
@@ -1,0 +1,50 @@
+package com.triptune.global.util;
+
+import com.triptune.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class NicknameGenerator {
+    private static final String[] adjectives = {
+        "신나는", "즐거운", "반짝이는", "행복한", "포근한", "느긋한", "설레는", "따뜻한", "짜릿한", "평화로운",
+            "놀라운", "자유로운", "유쾌한", "멋진", "빠른"
+    };
+
+    private static final String[] nouns = {
+        "여행자", "방랑자", "나그네", "떠돌이", "탐험가", "모험가", "뚜벅이", "유랑객", "여행객", "유목민"
+    };
+
+    private static final Random random = new Random();
+
+    private final MemberRepository memberRepository;
+
+
+    public String createNickname(){
+        while(true){
+            String nickname = generateRandomNickname();
+
+            if (!validateUniqueNickname(nickname)){
+                return nickname;
+            }
+        }
+    }
+
+
+    private boolean validateUniqueNickname(String nickname){
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    public static String generateRandomNickname(){
+        String adjective = adjectives[random.nextInt(adjectives.length)];
+        String noun = nouns[random.nextInt(nouns.length)];
+
+        int number = random.nextInt(999) + 1;
+        String formattedNumber = String.format("%03d", number);
+
+        return adjective + noun + formattedNumber;
+    }
+}

--- a/src/main/java/com/triptune/member/entity/Member.java
+++ b/src/main/java/com/triptune/member/entity/Member.java
@@ -81,11 +81,11 @@ public class Member {
                 .build();
     }
 
-    public static Member from(ProfileImage profileImage, OAuth2UserInfo oAuth2UserInfo){
+    public static Member from(ProfileImage profileImage, OAuth2UserInfo oAuth2UserInfo, String nickname){
         return Member.builder()
                 .profileImage(profileImage)
                 .email(oAuth2UserInfo.getEmail())
-                .nickname(oAuth2UserInfo.getNickname())
+                .nickname(nickname)
                 .joinType(JoinType.SOCIAL)
                 .createdAt(LocalDateTime.now())
                 .isActive(true)

--- a/src/main/java/com/triptune/member/entity/Member.java
+++ b/src/main/java/com/triptune/member/entity/Member.java
@@ -6,15 +6,18 @@ import com.triptune.member.enums.AnonymousValue;
 import com.triptune.member.enums.JoinType;
 import com.triptune.profile.entity.ProfileImage;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -101,17 +104,17 @@ public class Member {
 
     public void updatePassword(String password) {
         this.password = password;
-        this.updatedAt = LocalDateTime.now();
+        updateUpdatedAt();
     }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
-        this.updatedAt = LocalDateTime.now();
+        updateUpdatedAt();
     }
 
     public void updateEmail(String email) {
         this.email = email;
-        this.updatedAt = LocalDateTime.now();
+        updateUpdatedAt();
     }
 
     public void updateDeactivate() {
@@ -122,16 +125,22 @@ public class Member {
         this.email = unknown;
         this.password = unknown;
         this.refreshToken = null;
-        this.updatedAt = LocalDateTime.now();
         this.isActive = false;
-    }
-
-    public void updateUpdatedAt() {
-        this.updatedAt = LocalDateTime.now();
+        updateUpdatedAt();
     }
 
     public void updateProfileImage(ProfileImage profileImage) {
         this.profileImage = profileImage;
+        updateUpdatedAt();
+    }
+
+    public void updateJoinType(JoinType joinType){
+        this.joinType = joinType;
+        updateUpdatedAt();
+    }
+
+    public void updateUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/triptune/member/entity/Member.java
+++ b/src/main/java/com/triptune/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.triptune.member.entity;
 import com.triptune.global.security.oauth.userinfo.OAuth2UserInfo;
 import com.triptune.member.dto.request.JoinRequest;
 import com.triptune.member.enums.AnonymousValue;
+import com.triptune.member.enums.JoinType;
 import com.triptune.profile.entity.ProfileImage;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -37,8 +38,9 @@ public class Member {
     @Column(name = "refresh_token")
     private String refreshToken;
 
-    @Column(name = "is_social_login")
-    private boolean isSocialLogin;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "join_type")
+    private JoinType joinType;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -51,14 +53,14 @@ public class Member {
 
 
     @Builder
-    public Member(Long memberId, ProfileImage profileImage, String email, String password, String nickname, String refreshToken, boolean isSocialLogin, LocalDateTime createdAt, LocalDateTime updatedAt, boolean isActive) {
+    public Member(Long memberId, ProfileImage profileImage, String email, String password, String nickname, String refreshToken, JoinType joinType, LocalDateTime createdAt, LocalDateTime updatedAt, boolean isActive) {
         this.memberId = memberId;
         this.profileImage = profileImage;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.refreshToken = refreshToken;
-        this.isSocialLogin = isSocialLogin;
+        this.joinType = joinType;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.isActive = isActive;
@@ -70,7 +72,7 @@ public class Member {
                 .email(joinRequest.getEmail())
                 .password(encodePassword)
                 .nickname(joinRequest.getNickname())
-                .isSocialLogin(false)
+                .joinType(JoinType.NATIVE)
                 .createdAt(LocalDateTime.now())
                 .isActive(true)
                 .build();
@@ -81,7 +83,7 @@ public class Member {
                 .profileImage(profileImage)
                 .email(oAuth2UserInfo.getEmail())
                 .nickname(oAuth2UserInfo.getNickname())
-                .isSocialLogin(true)
+                .joinType(JoinType.SOCIAL)
                 .createdAt(LocalDateTime.now())
                 .isActive(true)
                 .build();

--- a/src/main/java/com/triptune/member/entity/SocialMember.java
+++ b/src/main/java/com/triptune/member/entity/SocialMember.java
@@ -54,4 +54,5 @@ public class SocialMember {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
 }

--- a/src/main/java/com/triptune/member/enums/JoinType.java
+++ b/src/main/java/com/triptune/member/enums/JoinType.java
@@ -1,0 +1,5 @@
+package com.triptune.member.enums;
+
+public enum JoinType {
+    NATIVE, SOCIAL, BOTH;
+}

--- a/src/main/java/com/triptune/member/repository/MemberRepository.java
+++ b/src/main/java/com/triptune/member/repository/MemberRepository.java
@@ -19,4 +19,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     @Modifying
     @Query("update Member m set m.refreshToken = NULL where m.nickname = :nickname")
     void deleteRefreshTokenByNickname(@Param("nickname") String nickname);
+
+    @Query("select m from Member m where m.email = :email and m.joinType = 'NATIVE'")
+    Optional<Member> findNativeMemberByEmail(@Param("email") String email);
 }

--- a/src/test/java/com/triptune/BaseTest.java
+++ b/src/test/java/com/triptune/BaseTest.java
@@ -47,19 +47,18 @@ public abstract class BaseTest {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
-
     protected Member createMember(Long memberId, String email, ProfileImage profileImage){
         return Member.builder()
                 .memberId(memberId)
                 .profileImage(profileImage)
                 .email(email)
-                .password("test123@")
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
                 .joinType(JoinType.NATIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
 
     protected Member createMember(Long memberId, String email, String encodePassword, ProfileImage profileImage){
         return Member.builder()
@@ -74,11 +73,12 @@ public abstract class BaseTest {
                 .build();
     }
 
-    protected Member createMember(Long memberId, String email, JoinType joinType, ProfileImage profileImage){
+    protected Member createMember(Long memberId, String email, String encodePassword, JoinType joinType, ProfileImage profileImage){
         return Member.builder()
                 .memberId(memberId)
                 .profileImage(profileImage)
                 .email(email)
+                .password(encodePassword)
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
                 .joinType(joinType)

--- a/src/test/java/com/triptune/BaseTest.java
+++ b/src/test/java/com/triptune/BaseTest.java
@@ -7,6 +7,7 @@ import com.triptune.common.entity.*;
 import com.triptune.global.security.CustomUserDetails;
 import com.triptune.member.entity.Member;
 import com.triptune.member.entity.SocialMember;
+import com.triptune.member.enums.JoinType;
 import com.triptune.member.enums.SocialType;
 import com.triptune.profile.entity.ProfileImage;
 import com.triptune.schedule.entity.ChatMessage;
@@ -42,7 +43,7 @@ public abstract class BaseTest {
                 .password("test123@")
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
-                .isSocialLogin(false)
+                .joinType(JoinType.NATIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -55,7 +56,7 @@ public abstract class BaseTest {
                 .password("test123@")
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
-                .isSocialLogin(false)
+                .joinType(JoinType.NATIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -68,19 +69,19 @@ public abstract class BaseTest {
                 .password(encodePassword)
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
-                .isSocialLogin(false)
+                .joinType(JoinType.NATIVE)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    protected Member createMember(Long memberId, String email, boolean isSocialLogin, ProfileImage profileImage){
+    protected Member createMember(Long memberId, String email, JoinType joinType, ProfileImage profileImage){
         return Member.builder()
                 .memberId(memberId)
                 .profileImage(profileImage)
                 .email(email)
                 .nickname(email.split("@")[0])
                 .refreshToken(refreshToken)
-                .isSocialLogin(isSocialLogin)
+                .joinType(joinType)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/com/triptune/global/SocialMemberTest.java
+++ b/src/test/java/com/triptune/global/SocialMemberTest.java
@@ -7,12 +7,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SocialMemberTest extends BaseTest {
-    protected NaverUserInfo createNaverUserInfo(String email, String nickname){
+    protected NaverUserInfo createNaverUserInfo(String email){
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("response", Map.of(
                 "id", "naverMember",
-                "email", email,
-                "nickname", nickname
+                "email", email
         ));
         return new NaverUserInfo(attributes);
     }

--- a/src/test/java/com/triptune/global/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/triptune/global/service/CustomOAuth2UserServiceTest.java
@@ -19,15 +19,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CustomOAuth2UserServiceTest extends SocialMemberTest {
@@ -36,21 +38,28 @@ class CustomOAuth2UserServiceTest extends SocialMemberTest {
     @Mock private SocialMemberRepository socialMemberRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private ProfileImageService profileImageService;
+    @Mock private PasswordEncoder passwordEncoder;
 
     @Test
-    @DisplayName("소셜 회원 정보가 저장되어 있는 경우 - 네이버")
-    void getOrCreateSocialMember_get_naver() {
+    @DisplayName("소셜 회원 로그인 - 네이버")
+    void joinOrLogin_socialLogin_naver() {
         // given
         OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
 
         ProfileImage profileImage = createProfileImage(1L, "image");
-        Member member = createMember(1L, "member@email.com", JoinType.SOCIAL, profileImage);
-        SocialMember socialMember = createSocialMember(1L, member, oAuth2UserInfo.getSocialId(), SocialType.NAVER);
+        Member member = createMember(
+                1L,
+                oAuth2UserInfo.getEmail(),
+                null,
+                JoinType.SOCIAL,
+                profileImage
+        );
 
-        when(socialMemberRepository.findBySocialIdAndSocialType(anyString(), any())).thenReturn(Optional.of(member));
+        when(socialMemberRepository.findBySocialIdAndSocialType(anyString(), any()))
+                .thenReturn(Optional.of(member));
 
         // when
-        Member response = customOAuth2UserService.getOrCreateSocialMember(oAuth2UserInfo);
+        Member response = customOAuth2UserService.joinOrLogin(oAuth2UserInfo);
 
         // then
         assertThat(response.getEmail()).isEqualTo(oAuth2UserInfo.getEmail());
@@ -61,23 +70,89 @@ class CustomOAuth2UserServiceTest extends SocialMemberTest {
     }
 
     @Test
-    @DisplayName("소셜 회원 생성 - 네이버")
-    void getOrCreateSocialMember_create_naver() {
+    @DisplayName("통합 회원 로그인 - 네이버")
+    void joinOrLogin_integrateLogin_naver() {
         // given
         OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
 
         ProfileImage profileImage = createProfileImage(1L, "image");
-        Member member = createMember(1L, "member@email.com", JoinType.SOCIAL, profileImage);
-        SocialMember socialMember = createSocialMember(1L, member, oAuth2UserInfo.getSocialId(), SocialType.NAVER);
+        Member member = createMember(
+                1L,
+                "nativeMember@email.com",
+                passwordEncoder.encode("password12!@"),
+                JoinType.BOTH,
+                profileImage
+        );
+
+        when(socialMemberRepository.findBySocialIdAndSocialType(anyString(), any()))
+                .thenReturn(Optional.of(member));
+
+        // when
+        Member response = customOAuth2UserService.joinOrLogin(oAuth2UserInfo);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(member.getEmail());
+        assertThat(response.getPassword()).isEqualTo(member.getPassword());
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.BOTH);
+
+    }
+
+    @Test
+    @DisplayName("회원가입 시 회원 통합 - 네이버")
+    void joinOrLogin_integrate_naver() {
+        // given
+        OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
+
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                "nativeMember@email.com",
+                passwordEncoder.encode("password12!@"),
+                JoinType.NATIVE,
+                profileImage
+        );
 
         when(socialMemberRepository.findBySocialIdAndSocialType(anyString(), any())).thenReturn(Optional.empty());
-        when(memberRepository.existsByEmail(anyString())).thenReturn(false);
+        when(memberRepository.findNativeMemberByEmail(anyString())).thenReturn(Optional.of(member));
+
+        // when
+        Member response = customOAuth2UserService.joinOrLogin(oAuth2UserInfo);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(member.getEmail());
+        assertThat(response.getPassword()).isEqualTo(member.getPassword());
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.BOTH);
+        assertThat(response.getUpdatedAt()).isNotNull();
+
+        verify(socialMemberRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("회원가입 시 신규 회원 생성 - 네이버")
+    void joinOrLogin_create_naver() {
+        // given
+        OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
+
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                oAuth2UserInfo.getEmail(),
+                null,
+                JoinType.SOCIAL,
+                profileImage
+        );
+
+        when(socialMemberRepository.findBySocialIdAndSocialType(anyString(), any())).thenReturn(Optional.empty());
         when(memberRepository.existsByNickname(anyString())).thenReturn(false);
         when(profileImageService.saveDefaultProfileImage()).thenReturn(profileImage);
         when(memberRepository.save(any())).thenReturn(member);
 
         // when
-        Member response = customOAuth2UserService.getOrCreateSocialMember(oAuth2UserInfo);
+        Member response = customOAuth2UserService.joinOrLogin(oAuth2UserInfo);
 
         // then
         assertThat(response.getEmail()).isEqualTo(oAuth2UserInfo.getEmail());
@@ -85,37 +160,151 @@ class CustomOAuth2UserServiceTest extends SocialMemberTest {
         assertThat(response.getNickname()).isEqualTo(oAuth2UserInfo.getNickname());
         assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
         assertThat(response.getJoinType()).isEqualTo(JoinType.SOCIAL);
+
+        verify(socialMemberRepository, times(1)).save(any());
     }
 
     @Test
-    @DisplayName("소셜 사용자 추가 시 이메일 중복으로 예외 발생")
-    void createSocialMember_duplicateEmail() {
+    @DisplayName("기존 회원인지 체크 후 기존 회원 통합 - 네이버")
+    void processSocialLogin_integrate_naver() {
         // given
         OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
 
-        when(memberRepository.existsByEmail(anyString())).thenReturn(true);
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                "nativeMember@email.com",
+                passwordEncoder.encode("password12!@"),
+                JoinType.NATIVE,
+                profileImage
+        );
+
+        when(memberRepository.findNativeMemberByEmail(anyString())).thenReturn(Optional.of(member));
 
         // when
-        DataExistException fail = assertThrows(DataExistException.class,
-                () -> customOAuth2UserService.createSocialMember(oAuth2UserInfo));
+        Member response = customOAuth2UserService.processSocialLogin(oAuth2UserInfo);
 
         // then
-        assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.ALREADY_EXISTED_EMAIL.getStatus());
-        assertThat(fail.getMessage()).isEqualTo(ErrorCode.ALREADY_EXISTED_EMAIL.getMessage());
+        assertThat(response.getEmail()).isEqualTo(member.getEmail());
+        assertThat(response.getPassword()).isEqualTo(member.getPassword());
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.BOTH);
+
     }
+
+    @Test
+    @DisplayName("기존 회원인지 체크 후 신규 생성 - 네이버")
+    void processSocialLogin_create_naver() {
+        // given
+        OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
+
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                oAuth2UserInfo.getEmail(),
+                null,
+                JoinType.SOCIAL,
+                profileImage
+        );
+        createSocialMember(1L, member, oAuth2UserInfo.getSocialId(), SocialType.NAVER);
+
+        when(memberRepository.findNativeMemberByEmail(anyString())).thenReturn(Optional.empty());
+        when(memberRepository.existsByNickname(anyString())).thenReturn(false);
+        when(profileImageService.saveDefaultProfileImage()).thenReturn(profileImage);
+        when(memberRepository.save(any())).thenReturn(member);
+
+        // when
+        Member response = customOAuth2UserService.processSocialLogin(oAuth2UserInfo);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(oAuth2UserInfo.getEmail());
+        assertThat(response.getPassword()).isNull();
+        assertThat(response.getNickname()).isEqualTo(oAuth2UserInfo.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.SOCIAL);
+
+        verify(socialMemberRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("회원 통합 - 네이버")
+    void integrateMember_naver() {
+        // given
+        OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
+
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                "nativeMember@email.com",
+                passwordEncoder.encode("password12!@"),
+                JoinType.NATIVE,
+                profileImage
+        );
+
+        // when
+        Member response = customOAuth2UserService.integrateMember(member, oAuth2UserInfo);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(member.getEmail());
+        assertThat(response.getPassword()).isNull();
+        assertThat(response.getNickname()).isEqualTo(member.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.BOTH);
+        assertThat(response.getUpdatedAt()).isNotNull();
+
+        verify(socialMemberRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 소셜 회원 생성 - 네이버")
+    void createMember_naver() {
+        // given
+        OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
+
+        ProfileImage profileImage = createProfileImage(1L, "image");
+        Member member = createMember(
+                1L,
+                oAuth2UserInfo.getEmail(),
+                null,
+                JoinType.SOCIAL,
+                profileImage
+        );
+
+        createSocialMember(1L, member, oAuth2UserInfo.getSocialId(), SocialType.NAVER);
+
+        when(memberRepository.existsByNickname(anyString())).thenReturn(false);
+        when(profileImageService.saveDefaultProfileImage()).thenReturn(profileImage);
+        when(memberRepository.save(any())).thenReturn(member);
+
+        // when
+        Member response = customOAuth2UserService.createMember(oAuth2UserInfo);
+
+        // then
+        assertThat(response.getEmail()).isEqualTo(oAuth2UserInfo.getEmail());
+        assertThat(response.getPassword()).isNull();
+        assertThat(response.getNickname()).isEqualTo(oAuth2UserInfo.getNickname());
+        assertThat(response.getProfileImage().getS3ObjectUrl()).isEqualTo(profileImage.getS3ObjectUrl());
+        assertThat(response.getJoinType()).isEqualTo(JoinType.SOCIAL);
+        assertThat(response.getCreatedAt()).isNotNull();
+        assertThat(response.getUpdatedAt()).isNull();
+
+        verify(socialMemberRepository, times(1)).save(any());
+    }
+
+
 
     @Test
     @DisplayName("소셜 사용자 추가 시 닉네임 중복으로 예외 발생")
-    void createSocialMember_duplicateNickname() {
+    void createMember_duplicateNickname() {
         // given
         OAuth2UserInfo oAuth2UserInfo = createNaverUserInfo("member@email.com", "member");
 
-        when(memberRepository.existsByEmail(anyString())).thenReturn(false);
         when(memberRepository.existsByNickname(anyString())).thenReturn(true);
 
         // when
         DataExistException fail = assertThrows(DataExistException.class,
-                () -> customOAuth2UserService.createSocialMember(oAuth2UserInfo));
+                () -> customOAuth2UserService.createMember(oAuth2UserInfo));
 
         // then
         assertThat(fail.getHttpStatus()).isEqualTo(ErrorCode.ALREADY_EXISTED_NICKNAME.getStatus());

--- a/src/test/java/com/triptune/global/util/NicknameGeneratorTest.java
+++ b/src/test/java/com/triptune/global/util/NicknameGeneratorTest.java
@@ -1,0 +1,74 @@
+package com.triptune.global.util;
+
+import com.triptune.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class NicknameGeneratorTest {
+
+    @InjectMocks private NicknameGenerator nicknameGenerator;
+    @Mock private MemberRepository memberRepository;
+
+
+    @Test
+    @DisplayName("닉네임 생성")
+    void createNickname() {
+        // given
+        when(memberRepository.existsByNickname(anyString())).thenReturn(false);
+
+        // when
+        String response = nicknameGenerator.createNickname();
+
+        // then
+        log.info("[닉네임] " + response);
+        assertThat(response).isNotNull();
+        assertThat(response).matches("[가-힣]+[가-힣]+\\d{3}");
+    }
+
+    @Test
+    @DisplayName("닉네임 생성 시 중복")
+    void createNickname_duplicateNickname() {
+        // given
+        when(memberRepository.existsByNickname(anyString()))
+                .thenReturn(true)
+                .thenReturn(true)
+                .thenReturn(false);
+
+        // when
+        String response = nicknameGenerator.createNickname();
+
+        // then
+        log.info("[닉네임] " + response);
+        assertThat(response).isNotNull();
+        assertThat(response).matches("[가-힣]+[가-힣]+\\d{3}");
+
+        verify(memberRepository, times(3)).existsByNickname(anyString());
+    }
+
+    @RepeatedTest(10)
+    @DisplayName("랜덤 닉네임 생성")
+    void generateRandomNickname() {
+        // given
+        // when
+        String response = NicknameGenerator.generateRandomNickname();
+
+        // then
+        log.info("[닉네임] " + response);
+        assertThat(response).isNotNull();
+        assertThat(response).matches("[가-힣]+[가-힣]+\\d{3}");
+    }
+
+}

--- a/src/test/java/com/triptune/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/triptune/member/controller/MemberControllerTest.java
@@ -9,6 +9,7 @@ import com.triptune.common.repository.ApiCategoryRepository;
 import com.triptune.common.repository.CityRepository;
 import com.triptune.common.repository.CountryRepository;
 import com.triptune.common.repository.DistrictRepository;
+import com.triptune.member.enums.JoinType;
 import com.triptune.member.enums.SocialType;
 import com.triptune.member.repository.SocialMemberRepository;
 import com.triptune.schedule.entity.TravelSchedule;
@@ -268,7 +269,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 로그인 정보만 있는 사용자가 자체 로그인 시도해 예외 발생")
     void login_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", true, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         mockMvc.perform(post("/api/members/login")
@@ -415,7 +416,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 사용자 비밀번호 찾기")
     void findPassword_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", true, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         mockMvc.perform(post("/api/members/find-password")
@@ -459,7 +460,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 사용자 비밀번호 초기화")
     void resetPassword_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", true, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         when(redisService.getData(anyString())).thenReturn(member.getEmail());

--- a/src/test/java/com/triptune/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/triptune/member/controller/MemberControllerTest.java
@@ -269,7 +269,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 로그인 정보만 있는 사용자가 자체 로그인 시도해 예외 발생")
     void login_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", null, JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         mockMvc.perform(post("/api/members/login")
@@ -416,7 +416,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 사용자 비밀번호 찾기")
     void findPassword_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", null, JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         mockMvc.perform(post("/api/members/find-password")
@@ -460,7 +460,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("소셜 사용자 비밀번호 초기화")
     void resetPassword_socialMember() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "member"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", null, JoinType.SOCIAL, profileImage));
         socialMemberRepository.save(createSocialMember(null, member, "member", SocialType.NAVER));
 
         when(redisService.getData(anyString())).thenReturn(member.getEmail());
@@ -618,7 +618,7 @@ public class MemberControllerTest extends MemberTest {
     @DisplayName("사용자 정보 조회")
     void getMemberInfo() throws Exception{
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "profileImage"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", passwordEncoder.encode("password12!@"), profileImage));
 
         mockAuthentication(member);
 

--- a/src/test/java/com/triptune/member/repository/SocialMemberRepositoryTest.java
+++ b/src/test/java/com/triptune/member/repository/SocialMemberRepositoryTest.java
@@ -32,7 +32,7 @@ class SocialMemberRepositoryTest extends MemberTest {
     void findBySocialInfo() {
         // given
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "image"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", null, JoinType.SOCIAL, profileImage));
         SocialMember socialMember = socialMemberRepository.save(createSocialMember(null, member, "socialMember", SocialType.NAVER));
 
         // when

--- a/src/test/java/com/triptune/member/repository/SocialMemberRepositoryTest.java
+++ b/src/test/java/com/triptune/member/repository/SocialMemberRepositoryTest.java
@@ -4,6 +4,7 @@ import com.triptune.global.config.QueryDSLConfig;
 import com.triptune.member.MemberTest;
 import com.triptune.member.entity.Member;
 import com.triptune.member.entity.SocialMember;
+import com.triptune.member.enums.JoinType;
 import com.triptune.member.enums.SocialType;
 import com.triptune.profile.entity.ProfileImage;
 import com.triptune.profile.repository.ProfileImageRepository;
@@ -31,7 +32,7 @@ class SocialMemberRepositoryTest extends MemberTest {
     void findBySocialInfo() {
         // given
         ProfileImage profileImage = profileImageRepository.save(createProfileImage(null, "image"));
-        Member member = memberRepository.save(createMember(null, "member@email.com", true, profileImage));
+        Member member = memberRepository.save(createMember(null, "member@email.com", JoinType.SOCIAL, profileImage));
         SocialMember socialMember = socialMemberRepository.save(createSocialMember(null, member, "socialMember", SocialType.NAVER));
 
         // when


### PR DESCRIPTION
## 신규 기능
- #168 
1. 닉네임 랜덤 생성
2. 간편 로그인과 자체 로그인 구분값 지정(enum)

## 수정 기능
- #168  
1. 이메일 중복 시 통합 계정으로 변경