### PR TITLE
[fix] 여행지탐색 사용자 권한 처리 수정 #173

### DIFF
--- a/src/main/java/com/triptune/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/triptune/global/security/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import static com.triptune.global.security.config.SecurityConstants.AUTH_TRAVEL_LIST;
 import static com.triptune.global.security.config.SecurityConstants.AUTH_WHITELIST;
 
 @RequiredArgsConstructor
@@ -53,6 +54,7 @@ public class SecurityConfig {
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .requestMatchers(AUTH_TRAVEL_LIST).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/triptune/global/security/config/SecurityConstants.java
+++ b/src/main/java/com/triptune/global/security/config/SecurityConstants.java
@@ -10,8 +10,13 @@ public class SecurityConstants {
     public static final String[] AUTH_WHITELIST = {
             "/swagger-ui/**", "/v3/api-docs/**", "/api/members/join", "/api/members/login",
             "/api/members/refresh", "/api/members/find-id", "/api/members/find-password",
-            "/api/members/reset-password", "/api/emails/**", "/api/travels/**", "/h2-console/**",
-            "/", "/error", "/ws", "/oauth2/authorization/**", "/login/oauth2/**"
+            "/api/members/reset-password", "/api/emails/**", "/api/travels/popular",
+            "/api/travels/recommend", "/h2-console/**", "/", "/error", "/ws",
+            "/oauth2/authorization/**", "/login/oauth2/**"
+    };
+
+    public static final String[] AUTH_TRAVEL_LIST = {
+            "/api/travels/**"
     };
 
     private SecurityConstants(){
@@ -19,6 +24,11 @@ public class SecurityConstants {
 
     public static boolean isWhitelisted(String requestURI){
         return Arrays.stream(AUTH_WHITELIST)
+                .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
+    }
+
+    public static boolean isTargetedTravelEndpoint(String requestURI){
+        return Arrays.stream(AUTH_TRAVEL_LIST)
                 .anyMatch(pattern -> pathMatcher.match(pattern, requestURI));
     }
 }


### PR DESCRIPTION
## 버그 수정
- #173 

> 여행지 탐색에서 로그인한 사용자의 북마크 표시 처리가 안되는 상황 파악

JwtAuthFilter 에서 화이트리스트에 포함된 uri 는 전부 setAuthentication 설정 하지 않고 통과함
여행지 탐색의 경우 로그인한 사용자는 **토큰 검증과 인증 처리**를 익명 사용자는 **통과**하는 식으로 구현되어야함

#### 해결 방법
1. 화이트리스트에서 해당 여행지 탐색의 uri 제외 시킴
2. JwtAuthFilter 검증 수정 및  SecurityContextHolder.getContext().setAuthentication(auth) 설정
- 검증 필요 없는 요청 : 화이트리스트, 여행지 탐색의 익명 사용자
- 검증 필요한 요청 : 여행지 탐색의 로그인한 사용자, 그 외 나머지
** SecurityContextHolder.getContext().setAuthentication(auth) 를 설정해주지 않으면 Authentication은 익명 클래스(AnonymousAuthenticationToken)로 처리된다.
3. SecurityConfig 에서 여행지 탐색 permitAll() 설정
- filter 통과하더라도 config 에서 권한 검증을 하기 때문에 여기서 permitAll 시켜줘야한다.

