### PR TITLE
[fix] 채팅 시간 오류 수정 (설명 포함) #154

### DIFF
--- a/src/main/java/com/triptune/global/util/TimeUtils.java
+++ b/src/main/java/com/triptune/global/util/TimeUtils.java
@@ -1,6 +1,7 @@
 package com.triptune.global.util;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -10,7 +11,6 @@ public class TimeUtils {
     private static final int HOURS_IN_A_DAY = 24;
     private static final int MINUTES_IN_AN_HOUR = 60;
     private static final String DATE_PATTERN = "yyyy년 M월 d일";
-    private static final ZoneId TIMEZONE_UTC = ZoneId.of("UTC");
     private static final ZoneId TIMEZONE_KST = ZoneId.of("Asia/Seoul");
 
     public static String timeDuration(LocalDateTime updateTime){
@@ -51,13 +51,11 @@ public class TimeUtils {
     }
 
 
-    public static LocalDateTime convertToKST(LocalDateTime source){
+    public static LocalDateTime convertToKST(Instant source){
         if(source == null){
             return null;
         }
 
-        return source.atZone(TIMEZONE_UTC)
-                .withZoneSameInstant(TIMEZONE_KST)
-                .toLocalDateTime();
+        return LocalDateTime.ofInstant(source, TIMEZONE_KST);
     }
 }

--- a/src/main/java/com/triptune/schedule/entity/ChatMessage.java
+++ b/src/main/java/com/triptune/schedule/entity/ChatMessage.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Getter
@@ -23,10 +24,10 @@ public class ChatMessage {
     private Long scheduleId;
     private Long memberId;
     private String message;
-    private LocalDateTime timestamp;
+    private Instant timestamp;
 
     @Builder
-    public ChatMessage(String messageId, Long scheduleId, Long memberId, String message, LocalDateTime timestamp) {
+    public ChatMessage(String messageId, Long scheduleId, Long memberId, String message, Instant timestamp) {
         this.messageId = messageId;
         this.scheduleId = scheduleId;
         this.memberId = memberId;
@@ -39,7 +40,7 @@ public class ChatMessage {
                 .scheduleId(chatMessageRequest.getScheduleId())
                 .memberId(member.getMemberId())
                 .message(chatMessageRequest.getMessage())
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 }

--- a/src/test/java/com/triptune/BaseTest.java
+++ b/src/test/java/com/triptune/BaseTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -473,7 +474,7 @@ public abstract class BaseTest {
                 .scheduleId(scheduleId)
                 .memberId(member.getMemberId())
                 .message(message)
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 

--- a/src/test/java/com/triptune/global/util/TimeUtilsTest.java
+++ b/src/test/java/com/triptune/global/util/TimeUtilsTest.java
@@ -3,6 +3,7 @@ package com.triptune.global.util;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -269,13 +270,13 @@ public class TimeUtilsTest {
     @DisplayName("한국 시간으로 변경")
     void convertToKST(){
         // given
-        LocalDateTime testTime = LocalDateTime.now().minusHours(9);
+        Instant utcTime = Instant.parse("2025-05-20T15:00:00Z");
 
         // when
-        LocalDateTime response = TimeUtils.convertToKST(testTime);
+        LocalDateTime response = TimeUtils.convertToKST(utcTime);
 
         // then
-        assertThat(response).isEqualTo(testTime.plusHours(9));
+        assertThat(response).isEqualTo(LocalDateTime.of(2025, 5, 21, 0, 0, 0));
     }
 
 }


### PR DESCRIPTION
## 버그 수정
1. 채팅 시간 오류 수정
: 채팅 입력 시 한국시간이 아닌 UTC + 18 시간으로 보여짐

<br>

> ### 원인
DB 에 저장할 때 사용하는 VO 에서 채팅 시간의 타입을 LocalDateTime 으로 설정함으로써 KST나 UTC 같은 기준 시간대 정보 없이 저장됨
(채팅으로 MongoDB는 특성상 시간 관련 데이터는 UTC 로 변환함)

✅원인 흐름
1. VO 를 LocalDateTime 으로 이용 -> 기준 시간대 없음
2. MongoDB 에서 UTC 로 변환 -> 시간 혼동 발생
3. 응답 시 KST 로 변환 -> 이 과정에서 데이터 시간 +9 됨
4. 결과적으로 예측한 것과 다른 시간이 보여짐

<br>

> ### 해결 방법
VO 를 LocalDateTime -> Instant 로 변경해 UTC 로 저장되도록 변경