### PR TITLE
[refactor] service 코드에 웹 관련 기술 삭제 #230

### DIFF
--- a/src/main/java/com/triptune/global/security/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/triptune/global/security/oauth/handler/OAuth2SuccessHandler.java
@@ -18,8 +18,8 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-@Component
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
@@ -36,16 +36,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
         String accessToken = jwtUtils.createAccessToken(userDetails.getMemberId());
-        response.addHeader("Set-Cookie", cookieUtils.createCookie(CookieType.ACCESS_TOKEN, accessToken));
+        addCookie(response, CookieType.ACCESS_TOKEN, accessToken);
 
         String encodeNickname = URLEncoder.encode(userDetails.getName(), StandardCharsets.UTF_8);
-        response.addHeader("Set-Cookie", cookieUtils.createCookie(CookieType.NICKNAME, encodeNickname));
+        addCookie(response, CookieType.NICKNAME, encodeNickname);
+        addCookie(response, CookieType.REFRESH_TOKEN, userDetails.getRefreshToken());
 
-        response.addHeader("Set-Cookie", cookieUtils.createCookie(CookieType.REFRESH_TOKEN, userDetails.getRefreshToken()));
-
-        log.info("[Set-Cookie] accessToken   | maxAge={}s | HttpOnly={}",
+        log.info("[Set-Cookie] accessToken | maxAge={}s | HttpOnly={}",
                 CookieType.ACCESS_TOKEN.getMaxAgeSeconds(), CookieType.ACCESS_TOKEN.isHttpOnly());
-        log.info("[Set-Cookie] nickname      | maxAge={}s | HttpOnly={}",
+        log.info("[Set-Cookie] nickname | maxAge={}s | HttpOnly={}",
                 CookieType.NICKNAME.getMaxAgeSeconds(), CookieType.NICKNAME.isHttpOnly());
         log.info("[Set-Cookie] refreshToken | maxAge={}s | HttpOnly={}",
                 CookieType.REFRESH_TOKEN.getMaxAgeSeconds(), CookieType.REFRESH_TOKEN.isHttpOnly());
@@ -54,6 +53,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         response.sendRedirect(redirectURL);
         log.info("소셜 로그인 성공");
+    }
+
+    private void addCookie(HttpServletResponse response, CookieType cookieType, String value){
+        response.addHeader("Set-Cookie", cookieUtils.createCookie(cookieType, value));
     }
 
 }

--- a/src/main/java/com/triptune/global/util/CookieUtils.java
+++ b/src/main/java/com/triptune/global/util/CookieUtils.java
@@ -1,15 +1,24 @@
 package com.triptune.global.util;
 
 import com.triptune.global.security.CookieType;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @Component
 public class CookieUtils {
 
     @Value("${app.domain}")
     private String domainPath;
+
+    private static final String REFRESH_TOKEN_NAME = "refreshToken";
 
     public String createCookie(CookieType cookieType, String value){
         return ResponseCookie.from(cookieType.getKey(), value)
@@ -33,5 +42,23 @@ public class CookieUtils {
                 .sameSite("None")
                 .build()
                 .toString();
+    }
+
+
+    public Optional<String> getRefreshTokenFromCookie(HttpServletRequest request){
+        if (request.getCookies() == null){
+            return Optional.empty();
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(REFRESH_TOKEN_NAME))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+
+    public void deleteAllCookies(HttpServletResponse response){
+        Stream.of(CookieType.ACCESS_TOKEN, CookieType.REFRESH_TOKEN, CookieType.NICKNAME)
+                .forEach(type -> response.addHeader("Set-Cookie", deleteCookie(type)));
     }
 }

--- a/src/main/java/com/triptune/member/dto/LoginResult.java
+++ b/src/main/java/com/triptune/member/dto/LoginResult.java
@@ -1,0 +1,7 @@
+package com.triptune.member.dto;
+
+public record LoginResult(
+        String accessToken,
+        String refreshToken,
+        String nickname
+) { }

--- a/src/test/java/com/triptune/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/triptune/member/controller/MemberControllerTest.java
@@ -5,6 +5,7 @@ import com.triptune.bookmark.repository.BookmarkRepository;
 import com.triptune.common.entity.*;
 import com.triptune.common.repository.*;
 import com.triptune.email.dto.request.EmailRequest;
+import com.triptune.global.security.CookieType;
 import com.triptune.member.dto.request.*;
 import com.triptune.member.enums.JoinType;
 import com.triptune.member.enums.SocialType;
@@ -40,6 +41,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
@@ -526,12 +528,13 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(1);
+        assertThat(cookies.get(0))
+                .startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                .contains("Max-Age=" + CookieType.REFRESH_TOKEN.getMaxAgeSeconds())
+                .contains("HttpOnly");
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(1);
-        assertThat(cookies[0].getName()).isEqualTo("refreshToken");
-        assertThat(cookies[0].getValue()).isNotNull();
     }
 
     @Test
@@ -558,12 +561,12 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
-
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(1);
-        assertThat(cookies[0].getName()).isEqualTo("refreshToken");
-        assertThat(cookies[0].getValue()).isNotNull();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(1);
+        assertThat(cookies.get(0))
+                .startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                .contains("Max-Age=" + CookieType.REFRESH_TOKEN.getMaxAgeSeconds())
+                .contains("HttpOnly");
     }
 
 
@@ -731,10 +734,21 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+                );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
 
@@ -2208,10 +2222,21 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
     @Test
@@ -2252,10 +2277,21 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
     @Test
@@ -2296,10 +2332,21 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
 
@@ -2351,10 +2398,21 @@ public class MemberControllerTest extends MemberTest {
                 .andReturn();
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
 
@@ -2454,10 +2512,21 @@ public class MemberControllerTest extends MemberTest {
 
 
         // then
-        Cookie[] cookies = result.getResponse().getCookies();
+        List<String> cookies = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+        assertThat(cookies).hasSize(3);
 
-        assertThat(cookies).isNotNull();
-        assertThat(cookies.length).isEqualTo(3);
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.ACCESS_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.REFRESH_TOKEN.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
+        assertThat(cookies).anyMatch(c ->
+                c.startsWith(CookieType.NICKNAME.getKey() + "=")
+                        && c.contains("Max-Age=0")
+        );
     }
 
 


### PR DESCRIPTION
## 리팩토링
#230 
1. service 코드에서 웹 관련 기술 삭제
- 가독성 좋아짐
- service 가 HTTP 웹 관련 기술에 의존하지 않게 됨
- 단위 테스트 더 쉽게 가능
- 계층별 책임 명확해짐