### PR TITLE
[fix] aws 이미지 업로드 오류 수정 #250

### DIFF
--- a/src/main/java/com/triptune/global/s3/S3Service.java
+++ b/src/main/java/com/triptune/global/s3/S3Service.java
@@ -36,7 +36,7 @@ public class S3Service {
                     s3ObjectKey,
                     uploadFile.getInputStream(),
                     metadata
-            ).withCannedAcl(CannedAccessControlList.PublicRead));
+            ));
 
             log.info("[s3 이미지 업로드 성공] : {}", s3ObjectKey);
 


### PR DESCRIPTION
## 버그 수정
- #250 

<br>

### 1.  AWS S3 이미지 업로드 오류 수정
✅ 원인 : S3 버킷이 ACL 비활성화 상태인데 코드에서 ACL 설정하려해 AccessControlListNotSupported예외 발생
```
withCannedAcl(CannedAccessControlList.PublicRead)
```

✅ 해결

1. 해당 코드 제거
2. 버킷 정책은 조회(`s3:GetObject`) 만 허용
3. IAM 사용자에게 객체 생성(`PutObject`), 조회(`GetObject`), 삭제(`DeleteObject`) 권한 부여